### PR TITLE
Add service design and API reference documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,99 @@ programs learned routes into the kernel.
 
 **API Group:** `bgp.miloapis.com/v1alpha1`
 
+## Architecture
+
+```
+  CRD Producers                Controller                GoBGP + Kernel
+  ─────────────                ──────────                ──────────────
+  Node operator ──┐            ConfigReconciler   ───→   GoBGP SetBgp
+  Cluster disco   ├──→  CRDs   SessionReconciler  ───→   GoBGP AddPeer
+  Human operator ─┘            PolicyReconciler   ───→   BGPSession CRDs
+                               AdvertReconciler   ───→   GoBGP AddPath
+                               RoutePolicyRecon   ───→   GoBGP AddPolicy
+                               StatusPoller (10s) ───→   BGPSession.status
+                               RouteWatcher       ───→   netlink (proto 196)
+```
+
+The controller runs as a DaemonSet. Each node runs one controller instance alongside a GoBGP sidecar container. The controller connects to GoBGP via gRPC at `127.0.0.1:50051`. GoBGP is treated as stateless — if it restarts, the controller re-applies all CRD state automatically.
+
+## Custom Resources
+
+| Kind | Short Name | Scope | Purpose |
+|------|------------|-------|---------|
+| `BGPConfiguration` | `bgpconfig` | Cluster | Local speaker identity (AS number, port, router ID). One per cluster. |
+| `BGPEndpoint` | `bgpep` | Cluster | Self-advertisement: "I exist at this address with this AS." |
+| `BGPSession` | `bgpsess` | Cluster | Peering relationship between two endpoints. |
+| `BGPPeeringPolicy` | `bgppp` | Cluster | Automates session creation via label selectors. |
+| `BGPAdvertisement` | `bgpadvert` | Cluster | IPv6 prefix advertisement with optional communities and local-pref. |
+| `BGPRoutePolicy` | `bgprp` | Cluster | Import/export filtering rules. |
+
+## Quick Start
+
+**1. Declare the BGP speaker:**
+
+```yaml
+apiVersion: bgp.miloapis.com/v1alpha1
+kind: BGPConfiguration
+metadata:
+  name: default
+spec:
+  asNumber: 65001
+  listenPort: 1790       # non-privileged port (Galactic convention)
+  routerIDSource: NodeIP
+```
+
+**2. Declare endpoints (typically created by a node auto-peer operator):**
+
+```yaml
+apiVersion: bgp.miloapis.com/v1alpha1
+kind: BGPEndpoint
+metadata:
+  name: node-a
+  labels:
+    topology.example.com/region: us-east
+spec:
+  address: "2001:db8::1"
+  asNumber: 65001
+---
+apiVersion: bgp.miloapis.com/v1alpha1
+kind: BGPEndpoint
+metadata:
+  name: node-b
+  labels:
+    topology.example.com/region: us-east
+spec:
+  address: "2001:db8::2"
+  asNumber: 65001
+```
+
+**3. Automate peering with a policy:**
+
+```yaml
+apiVersion: bgp.miloapis.com/v1alpha1
+kind: BGPPeeringPolicy
+metadata:
+  name: us-east-mesh
+spec:
+  selector:
+    matchLabels:
+      topology.example.com/region: us-east
+  mode: mesh
+```
+
+**4. Check session state:**
+
+```bash
+kubectl get bgpsessions
+# NAME             LOCAL    REMOTE    SESSION       RX PREFIXES
+# node-a--node-b   node-a   node-b    Established   4
+```
+
+## Documentation
+
+- [Service Design](docs/design/README.md) — Architecture, motivation, three-layer model, design decisions
+- [API Reference](docs/api/README.md) — Complete field documentation for all CRDs with examples
+
 ## Status
 
 This project is in early development (`v1alpha1`). APIs may change.

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -1,0 +1,518 @@
+---
+status: implementable
+stage: alpha
+---
+
+# API Reference: bgp.miloapis.com/v1alpha1
+
+> Last verified: 2026-03-16 against main (initial implementation)
+
+**API Group:** `bgp.miloapis.com`
+**Version:** `v1alpha1`
+**Stability:** Alpha — fields and defaults may change
+
+All resources in this API group are **cluster-scoped** because BGP topology spans namespace and cluster boundaries.
+
+## Resources
+
+| Kind | Short Name | Verbs | Phase |
+|------|------------|-------|-------|
+| [BGPConfiguration](#bgpconfiguration) | `bgpconfig` | get, list, watch, create, update, patch, delete | Alpha |
+| [BGPEndpoint](#bgpendpoint) | `bgpep` | get, list, watch, create, update, patch, delete | Alpha |
+| [BGPSession](#bgpsession) | `bgpsess` | get, list, watch, create, update, patch, delete | Alpha |
+| [BGPPeeringPolicy](#bgppeeringpolicy) | `bgppp` | get, list, watch, create, update, patch, delete | Alpha |
+| [BGPAdvertisement](#bgpadvertisement) | `bgpadvert` | get, list, watch, create, update, patch, delete | Alpha (Phase 2) |
+| [BGPRoutePolicy](#bgproutepolicy) | `bgprp` | get, list, watch, create, update, patch, delete | Alpha (Phase 2) |
+
+Phase 2 resources have their schemas registered and reconcilers running, but see limited production use in the alpha release.
+
+---
+
+## BGPConfiguration
+
+`BGPConfiguration` declares the local BGP speaker identity for the cluster. There should be exactly one `BGPConfiguration` per cluster, conventionally named `default`.
+
+The controller reads this resource to configure GoBGP's global AS number, router ID, and listen port. If GoBGP restarts, the controller re-applies this configuration as part of full re-reconciliation.
+
+```bash
+kubectl get bgpconfigurations
+kubectl get bgpconfig       # short name
+```
+
+Printed columns: `AS`, `Port`, `Ready`
+
+### Spec
+
+| Field | Type | Default | Required | Description |
+|-------|------|---------|----------|-------------|
+| `asNumber` | `uint32` | — | Yes | Local AS number. Range: 1–4294967295. For single-cluster iBGP, all nodes share the same AS. For multi-cluster eBGP, each cluster has a unique AS. |
+| `listenPort` | `int32` | `1790` | No | TCP port GoBGP listens on. 1790 is the Galactic convention (non-privileged, avoids conflicts with standard BGP port 179). Range: 1–65535. |
+| `routerIDSource` | `string` | `NodeIP` | No | Controls how the router ID is determined. `NodeIP` uses the node's IPv6 InternalIP. `Manual` requires `routerID` to be set explicitly. Enum: `NodeIP`, `Manual`. |
+| `routerID` | `string` | — | No | BGP router ID in dotted-decimal IPv4 notation (BGP convention, e.g. `10.0.0.1`). Required when `routerIDSource` is `Manual`. |
+| `addressFamilies` | `[]AddressFamily` | IPv6 unicast | No | Address families the speaker activates. Defaults to `[{afi: IPv6, safi: Unicast}]`. |
+
+#### AddressFamily
+
+| Field | Type | Default | Required | Description |
+|-------|------|---------|----------|-------------|
+| `afi` | `string` | — | Yes | Address Family Indicator. Enum: `IPv4`, `IPv6`. |
+| `safi` | `string` | `Unicast` | No | Subsequent Address Family Indicator. Enum: `Unicast`, `Multicast`. |
+
+### Status
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `conditions` | `[]metav1.Condition` | Current state of the BGP configuration. See [Conditions](#bgpconfiguration-conditions). |
+| `observedASNumber` | `uint32` | AS number currently configured in GoBGP. |
+| `observedRouterID` | `string` | Router ID currently configured in GoBGP. |
+
+#### BGPConfiguration Conditions
+
+| Type | Meaning |
+|------|---------|
+| `SpeakerReady` | GoBGP is running and configured with the spec values. `False` when GoBGP is unreachable or configuration failed. |
+
+### Example
+
+```yaml
+apiVersion: bgp.miloapis.com/v1alpha1
+kind: BGPConfiguration
+metadata:
+  name: default          # convention: one per cluster, named "default"
+spec:
+  asNumber: 65001        # private AS range: 64512–65534
+  listenPort: 1790       # non-privileged port (Galactic convention)
+  routerIDSource: NodeIP # derive router ID from node's IPv6 address
+  addressFamilies:
+    - afi: IPv6
+      safi: Unicast
+```
+
+---
+
+## BGPEndpoint
+
+`BGPEndpoint` declares a BGP speaker endpoint — an IPv6 address and AS number that other speakers can peer with. An endpoint is a self-advertisement: "I exist at this address, with this AS."
+
+Endpoints are typically created by a node auto-peer operator (one `BGPEndpoint` per node) or manually by platform operators. `BGPPeeringPolicy` resources use label selectors on endpoints to automate session creation.
+
+```bash
+kubectl get bgpendpoints
+kubectl get bgpep         # short name
+```
+
+Printed columns: `Address`, `ASN`
+
+### Spec
+
+| Field | Type | Default | Required | Description |
+|-------|------|---------|----------|-------------|
+| `address` | `string` | — | Yes | IPv6 address of this BGP speaker. Must be a valid IPv6 address (format: `ipv6`). |
+| `asNumber` | `uint32` | — | Yes | AS number this endpoint belongs to. Range: 1–4294967295. |
+| `addressFamilies` | `[]AddressFamily` | IPv6 unicast | No | Address families this endpoint supports. See [AddressFamily](#addressfamily) above. |
+
+### Status
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `conditions` | `[]metav1.Condition` | Current state of the endpoint. No conditions are currently defined; reserved for future use. |
+
+### Example
+
+```yaml
+apiVersion: bgp.miloapis.com/v1alpha1
+kind: BGPEndpoint
+metadata:
+  name: node-worker-1    # typically matches the Kubernetes node name
+  labels:
+    topology.example.com/region: us-east
+    topology.example.com/cluster: prod-1
+spec:
+  address: "2001:db8::1" # node's primary IPv6 address
+  asNumber: 65001
+  addressFamilies:
+    - afi: IPv6
+      safi: Unicast
+```
+
+> [!NOTE]
+> Labels on `BGPEndpoint` resources are how `BGPPeeringPolicy` selectors drive topology. Use labels to express topology attributes (region, cluster, tier) that peering policies should target.
+
+---
+
+## BGPSession
+
+`BGPSession` declares a BGP peering relationship between two `BGPEndpoint` resources. Each session names a local endpoint and a remote endpoint by their resource names.
+
+Sessions are created by `BGPPeeringPolicy` controllers or manually by platform operators. Each node's BGP controller instance reconciles all `BGPSession` resources where `spec.localEndpoint` matches the value of its `--local-endpoint` flag, translating them into GoBGP `AddPeer`/`UpdatePeer` calls.
+
+```bash
+kubectl get bgpsessions
+kubectl get bgpsess        # short name
+```
+
+Printed columns: `Local`, `Remote`, `Session`, `RX Prefixes`
+
+### Spec
+
+| Field | Type | Default | Required | Description |
+|-------|------|---------|----------|-------------|
+| `localEndpoint` | `string` | — | Yes | Name of the local `BGPEndpoint` resource. The controller instance running with `--local-endpoint` matching this value will reconcile this session. |
+| `remoteEndpoint` | `string` | — | Yes | Name of the remote `BGPEndpoint` resource. The remote peer's address and AS number are read from this endpoint. |
+| `holdTime` | `int32` | `90` | No | BGP hold time in seconds. Minimum: 3. |
+| `keepaliveTime` | `int32` | `30` | No | BGP keepalive interval in seconds. Minimum: 1. |
+| `routeReflector` | `RouteReflectorConfig` | — | No | When set, configures this session for route reflector client behavior. The local speaker treats the remote peer as a route reflector client. |
+| `ebgpConfig` | `EBGPSessionConfig` | — | No | eBGP-specific session parameters. Only meaningful when the local and remote endpoints have different AS numbers. |
+
+#### RouteReflectorConfig
+
+| Field | Type | Default | Required | Description |
+|-------|------|---------|----------|-------------|
+| `clusterID` | `string` | — | Yes | Route reflector cluster ID in dotted-decimal IPv4 notation (BGP convention, e.g. `10.0.0.1`). |
+
+#### EBGPSessionConfig
+
+| Field | Type | Default | Required | Description |
+|-------|------|---------|----------|-------------|
+| `multiHop` | `EBGPMultiHop` | — | No | Enables eBGP multi-hop. Mutually exclusive with `ttlSecurity`. |
+| `ttlSecurity` | `EBGPTTLSecurity` | — | No | Enables GTSM (Generalized TTL Security Mechanism). Mutually exclusive with `multiHop`. |
+
+#### EBGPMultiHop
+
+| Field | Type | Default | Required | Description |
+|-------|------|---------|----------|-------------|
+| `ttl` | `uint32` | — | Yes | Maximum number of hops permitted. Range: 1–255. Sets GoBGP `EbgpMultihop.MultihopTtl`. |
+
+#### EBGPTTLSecurity
+
+| Field | Type | Default | Required | Description |
+|-------|------|---------|----------|-------------|
+| `ttl` | `uint32` | — | Yes | Expected minimum TTL for incoming eBGP packets. Range: 1–255. Sets GoBGP `TtlSecurity.TtlMin`. |
+
+### Status
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `sessionState` | `string` | Current BGP FSM state as reported by GoBGP, polled every 10 seconds. One of: `Unknown`, `Idle`, `Connect`, `Active`, `OpenSent`, `OpenConfirm`, `Established`. |
+| `conditions` | `[]metav1.Condition` | Current state of the session. See [Conditions](#bgpsession-conditions). |
+| `receivedPrefixes` | `int64` | Count of prefixes currently received from the remote peer (across all address families). |
+| `advertisedPrefixes` | `int64` | Count of prefixes currently advertised to the remote peer. |
+| `lastTransitionTime` | `metav1.Time` | Timestamp of the most recent session state change. |
+| `flapCount` | `int64` | Number of times this session has transitioned from `Established` to any other state. |
+
+#### BGPSession Conditions
+
+| Type | Meaning |
+|------|---------|
+| `SessionEstablished` | `True` when the BGP FSM is in `Established` state. `False` in all other states. |
+| `Configured` | `True` when the session has been successfully added to GoBGP via `AddPeer`/`UpdatePeer`. |
+
+### Examples
+
+**iBGP session (same AS):**
+
+```yaml
+apiVersion: bgp.miloapis.com/v1alpha1
+kind: BGPSession
+metadata:
+  name: node-a--node-b   # convention: local--remote
+spec:
+  localEndpoint: node-a
+  remoteEndpoint: node-b
+  holdTime: 90
+  keepaliveTime: 30
+```
+
+**Route reflector client session:**
+
+```yaml
+apiVersion: bgp.miloapis.com/v1alpha1
+kind: BGPSession
+metadata:
+  name: node-a--rr-1
+spec:
+  localEndpoint: node-a
+  remoteEndpoint: rr-1
+  routeReflector:
+    clusterID: "10.0.0.1"  # identifies the RR cluster
+```
+
+**eBGP session between clusters:**
+
+```yaml
+apiVersion: bgp.miloapis.com/v1alpha1
+kind: BGPSession
+metadata:
+  name: cluster-a-border--cluster-b-border
+spec:
+  localEndpoint: cluster-a-border   # AS 65001
+  remoteEndpoint: cluster-b-border  # AS 65002
+  holdTime: 90
+  keepaliveTime: 30
+  ebgpConfig:
+    multiHop:
+      ttl: 2   # peers are one hop apart
+```
+
+---
+
+## BGPPeeringPolicy
+
+`BGPPeeringPolicy` automates `BGPSession` creation by selecting `BGPEndpoint` resources via label selectors and creating sessions based on the chosen topology mode. The `PeeringPolicyReconciler` watches for endpoint changes and ensures the desired set of `BGPSession` objects exists.
+
+> [!IMPORTANT]
+> `BGPPeeringPolicy` creates and manages `BGPSession` resources. If you manually create a session that a policy would also create, the policy controller may conflict with it.
+
+```bash
+kubectl get bgppeeringpolicies
+kubectl get bgppp              # short name
+```
+
+Printed columns: `Mode`, `Endpoints`, `Sessions`
+
+### Spec
+
+| Field | Type | Default | Required | Description |
+|-------|------|---------|----------|-------------|
+| `selector` | `metav1.LabelSelector` | — | Yes | Selects `BGPEndpoint` resources to include in this policy. |
+| `mode` | `string` | `mesh` | No | Topology mode. `mesh` creates a `BGPSession` for every pair of matching endpoints (N*(N-1)/2 sessions for N endpoints). `route-reflector` creates sessions between the designated reflector and each client endpoint. Enum: `mesh`, `route-reflector`. |
+| `sessionTemplate` | `BGPSessionTemplate` | — | No | Default hold time and keepalive time for created sessions. |
+| `routeReflectorConfig` | `PeeringPolicyRRConfig` | — | No | Required when `mode` is `route-reflector`. Identifies the route reflector endpoint and assigns the cluster ID. |
+
+#### BGPSessionTemplate
+
+| Field | Type | Default | Required | Description |
+|-------|------|---------|----------|-------------|
+| `holdTime` | `int32` | — | No | BGP hold time in seconds for created sessions. |
+| `keepaliveTime` | `int32` | — | No | BGP keepalive interval in seconds for created sessions. |
+
+#### PeeringPolicyRRConfig
+
+| Field | Type | Default | Required | Description |
+|-------|------|---------|----------|-------------|
+| `reflectorSelector` | `metav1.LabelSelector` | — | Yes | Selects exactly one `BGPEndpoint` to act as the route reflector. If the selector matches more than one endpoint, the `InvalidConfig` condition is set and no sessions are created. |
+| `clusterID` | `string` | — | Yes | Route reflector cluster ID in dotted-decimal IPv4 notation. Assigned to all client sessions created by this policy. |
+
+### Status
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `conditions` | `[]metav1.Condition` | Current state of the policy. See [Conditions](#bgppeeringpolicy-conditions). |
+| `matchedEndpoints` | `int32` | Number of `BGPEndpoint` resources currently matching `spec.selector`. |
+| `activeSessions` | `int32` | Number of `BGPSession` resources currently created and managed by this policy. |
+
+#### BGPPeeringPolicy Conditions
+
+| Type | Meaning |
+|------|---------|
+| `InvalidConfig` | The policy spec is invalid — e.g., `route-reflector` mode with a `reflectorSelector` that matches zero or more than one endpoint. When set, no sessions are created or modified. |
+
+### Examples
+
+**Full mesh within a region:**
+
+```yaml
+apiVersion: bgp.miloapis.com/v1alpha1
+kind: BGPPeeringPolicy
+metadata:
+  name: us-east-mesh
+spec:
+  selector:
+    matchLabels:
+      topology.example.com/region: us-east
+  mode: mesh
+  sessionTemplate:
+    holdTime: 90
+    keepaliveTime: 30
+```
+
+**Route reflector topology:**
+
+```yaml
+apiVersion: bgp.miloapis.com/v1alpha1
+kind: BGPPeeringPolicy
+metadata:
+  name: us-east-rr
+spec:
+  selector:
+    matchLabels:
+      topology.example.com/region: us-east  # selects all endpoints (reflector + clients)
+  mode: route-reflector
+  routeReflectorConfig:
+    reflectorSelector:
+      matchLabels:
+        bgp.miloapis.com/role: route-reflector  # must match exactly one endpoint
+    clusterID: "10.0.0.1"
+```
+
+---
+
+## BGPAdvertisement
+
+`BGPAdvertisement` declares what IPv6 CIDR prefixes the local speaker should advertise into BGP. The `AdvertisementReconciler` injects declared prefixes into the GoBGP RIB using `AddPath`. On deletion, prefixes are withdrawn using `DeletePath`.
+
+> [!NOTE]
+> BGPAdvertisement is a Phase 2 resource. The schema is registered and the reconciler is running, but this resource sees limited use in the initial alpha deployment.
+
+```bash
+kubectl get bgpadvertisements
+kubectl get bgpadvert          # short name
+```
+
+### Spec
+
+| Field | Type | Default | Required | Description |
+|-------|------|---------|----------|-------------|
+| `prefixes` | `[]string` | — | Yes | List of IPv6 CIDR prefixes to advertise. Minimum 1 item. Example: `["2001:db8::/32"]`. |
+| `peerSelector` | `metav1.LabelSelector` | — | No | Selects which peers this advertisement targets. If omitted, the prefixes are advertised to all peers. |
+| `communities` | `[]string` | — | No | BGP community values to attach to advertised routes. Format: `"AS:value"` (e.g. `"65001:100"`). |
+| `localPref` | `*uint32` | — | No | LOCAL_PREF attribute value. Only meaningful for iBGP sessions. Minimum: 0. |
+
+### Status
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `conditions` | `[]metav1.Condition` | Current state of the advertisement. |
+| `advertisedPrefixCount` | `int32` | Number of prefixes currently present in the GoBGP RIB. |
+
+### Example
+
+```yaml
+apiVersion: bgp.miloapis.com/v1alpha1
+kind: BGPAdvertisement
+metadata:
+  name: node-1-srv6-prefix
+spec:
+  prefixes:
+    - "2001:db8:ff00::/48"   # this node's SRv6 prefix block
+  communities:
+    - "65001:100"            # internal routing community
+  localPref: 100             # prefer this path for iBGP
+```
+
+---
+
+## BGPRoutePolicy
+
+`BGPRoutePolicy` declares import or export filtering rules applied to BGP sessions. The `RoutePolicyReconciler` applies the policy to GoBGP's policy table using `AddPolicy`/`DeletePolicy`. Statements are evaluated in order; the first match wins.
+
+> [!NOTE]
+> BGPRoutePolicy is a Phase 2 resource. The schema is registered and the reconciler is running, but this resource sees limited use in the initial alpha deployment.
+
+```bash
+kubectl get bgproutepolicies
+kubectl get bgprp              # short name
+```
+
+### Spec
+
+| Field | Type | Default | Required | Description |
+|-------|------|---------|----------|-------------|
+| `type` | `string` | — | Yes | Whether this is an `Import` or `Export` policy. Enum: `Import`, `Export`. |
+| `peerSelector` | `metav1.LabelSelector` | — | No | Selects which peers this policy applies to. If omitted, the policy applies to all peers. |
+| `statements` | `[]PolicyStatement` | — | Yes | Ordered list of policy rules. Minimum 1 item. First match wins. |
+
+#### PolicyStatement
+
+| Field | Type | Default | Required | Description |
+|-------|------|---------|----------|-------------|
+| `prefixSet` | `[]PrefixMatch` | — | No | Set of prefixes to match. If empty, the statement matches all prefixes. |
+| `action` | `string` | — | Yes | Action when the statement matches. Enum: `Accept`, `Reject`. |
+
+#### PrefixMatch
+
+| Field | Type | Default | Required | Description |
+|-------|------|---------|----------|-------------|
+| `cidr` | `string` | — | Yes | Prefix to match, e.g. `"2001:db8:ff00::/40"`. |
+| `maskLengthMin` | `*uint32` | — | No | Match only prefixes with mask length >= this value. Use with `maskLengthMax` to express a range. |
+| `maskLengthMax` | `*uint32` | — | No | Match only prefixes with mask length <= this value. |
+
+### Status
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `conditions` | `[]metav1.Condition` | Current state of the policy. |
+
+### Example
+
+Reject more-specific /48 prefixes when an aggregate /40 covers them (prevents leaking individual host routes when the aggregate is already being advertised):
+
+```yaml
+apiVersion: bgp.miloapis.com/v1alpha1
+kind: BGPRoutePolicy
+metadata:
+  name: reject-specifics-under-aggregate
+spec:
+  type: Export
+  statements:
+    - prefixSet:
+        - cidr: "2001:db8:ff00::/40"
+          maskLengthMin: 48   # match /48 and longer within this /40
+          maskLengthMax: 128
+      action: Reject
+    - action: Accept          # accept everything else
+```
+
+---
+
+## Planned Resources (Future)
+
+The following resources are planned for a future release to support SRv6 VPN overlays per RFC 9252. They are not present in `v1alpha1`.
+
+### BGPVPN (planned)
+
+Declares a VPN instance with route targets and SRv6 behavior. Encodes VPN membership and the SRv6 behavior type (e.g., End.DT6) for route advertisement.
+
+### BGPVPNRoute (planned)
+
+Declares a VPN route advertisement within a `BGPVPN` instance. Associates a prefix with a VPN and an SRv6 SID.
+
+---
+
+## Common Patterns
+
+### Labeling Endpoints for Policy Selection
+
+`BGPPeeringPolicy` selectors are the primary mechanism for topology automation. Establish a labeling convention for your endpoints:
+
+```yaml
+# Topology location
+topology.example.com/region: us-east
+topology.example.com/zone: us-east-1a
+topology.example.com/cluster: prod-1
+
+# BGP role
+bgp.miloapis.com/role: route-reflector  # or: client, border
+```
+
+### Naming Conventions
+
+| Resource | Convention | Example |
+|----------|------------|---------|
+| `BGPConfiguration` | `default` (one per cluster) | `default` |
+| `BGPEndpoint` | Kubernetes node name | `node-worker-1` |
+| `BGPSession` | `{local}--{remote}` | `node-a--node-b` |
+| `BGPPeeringPolicy` | `{scope}-{mode}` | `us-east-mesh` |
+| `BGPAdvertisement` | `{owner}-{description}` | `node-1-srv6-prefix` |
+| `BGPRoutePolicy` | descriptive | `reject-specifics-under-aggregate` |
+
+### Verifying Configuration
+
+After applying resources, verify the BGP controller has reconciled them:
+
+```bash
+# Check speaker is ready
+kubectl get bgpconfig default -o jsonpath='{.status.conditions[?(@.type=="SpeakerReady")].status}'
+
+# Check all sessions
+kubectl get bgpsessions -o wide
+
+# Watch session state changes
+kubectl get bgpsessions -w
+
+# Check a specific session's full status
+kubectl get bgpsession node-a--node-b -o yaml | grep -A 20 status:
+
+# Check peering policy created the expected sessions
+kubectl get bgppp us-east-mesh -o jsonpath='{.status}'
+```

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -1,0 +1,334 @@
+---
+status: implementable
+stage: alpha
+---
+
+# Service Design: Kubernetes-Native BGP Control Plane
+
+> Last verified: 2026-03-16 against main (initial implementation)
+
+## Table of Contents
+
+- [Summary](#summary)
+- [Motivation](#motivation)
+  - [Goals](#goals)
+  - [Non-Goals](#non-goals)
+- [Proposal](#proposal)
+  - [Developer Experience](#developer-experience)
+  - [Resource Model](#resource-model)
+  - [Three-Layer Architecture](#three-layer-architecture)
+- [Design Details](#design-details)
+  - [Controller Architecture](#controller-architecture)
+  - [GoBGP Sidecar Pattern](#gobgp-sidecar-pattern)
+  - [Session Lifecycle](#session-lifecycle)
+  - [Status Polling](#status-polling)
+  - [Resilience and Re-reconciliation](#resilience-and-re-reconciliation)
+  - [Metrics](#metrics)
+- [User Stories](#user-stories)
+- [Drawbacks](#drawbacks)
+- [Alternatives Considered](#alternatives-considered)
+
+---
+
+## Summary
+
+`datum-cloud/bgp` is a Kubernetes-native BGP control plane that manages BGP topology declaratively via Custom Resource Definitions (CRDs), powered by [GoBGP](https://github.com/osrg/gobgp). The API group is `bgp.miloapis.com/v1alpha1`.
+
+Resources represent things — endpoints, sessions, policies — not imperative commands. The controller is topology-agnostic: it reconciles CRDs into GoBGP gRPC calls without embedded knowledge of nodes, clusters, borders, or network topology. Any system that can create Kubernetes objects can produce BGP topology by writing BGP CRDs.
+
+> [!NOTE]
+> This project is in `v1alpha1`. APIs are subject to change. See the [API reference](../api/README.md) for current field documentation.
+
+---
+
+## Motivation
+
+BGP is fundamental to modern networking infrastructure. It is the protocol that connects routers, establishes reachability across AS boundaries, and carries the route information that makes global IP routing work. In cloud-native environments, BGP is equally central: it distributes pod CIDRs, advertises service VIPs, and, in overlay architectures, carries SRv6 segment lists between nodes.
+
+Existing Kubernetes BGP implementations — Cilium, Calico, MetalLB, Kube-Router — all embed BGP management within their CNI-specific controllers. This coupling has two consequences:
+
+1. **BGP topology is not reusable.** If you want to change your data plane, you also change your BGP management system. There is no standard Kubernetes API for "this node has a BGP speaker" or "these two speakers should peer."
+
+2. **BGP configuration is opaque.** You cannot inspect BGP session state with `kubectl`, write automation against BGP topology, or apply RBAC to BGP operations using standard Kubernetes tooling.
+
+This project decouples BGP topology management from the data plane. The control plane speaks BGP CRDs. The data plane is whatever system reads routes from the kernel FIB.
+
+### Goals
+
+- Declarative BGP topology management via Kubernetes CRDs — `kubectl apply` drives BGP.
+- Topology-agnostic controller with no knowledge of nodes, clusters, or network topology. The controller reconciles whatever CRDs exist.
+- Independent producer/consumer model: any system can create BGP CRDs; the controller reconciles them uniformly. Labels and selectors drive topology automation.
+- Support for iBGP, eBGP, route reflection, prefix advertisement, and route import/export policy.
+- Kernel FIB synchronization: learned BGP routes are programmed into the kernel routing table via netlink (proto 196).
+- SRv6 VPN overlay support (RFC 9252) as a planned extension (`BGPVPN`, `BGPVPNRoute` resources).
+- Status visibility: session FSM state, received/advertised prefix counts, and flap counters are surfaced on BGPSession resources and as Prometheus metrics.
+
+### Non-Goals
+
+- **CNI implementation.** This project does not configure network interfaces, assign pod IPs, or implement pod networking. It manages BGP sessions only.
+- **SRv6 encap/decap dataplane.** The route syncer programs next-hops into the kernel FIB; the kernel and hardware handle forwarding.
+- **Cluster discovery or fleet management.** Discovering peers across clusters is the responsibility of a higher-level operator (e.g., the node auto-peer operator).
+- **BGP security** (MD5 authentication, TCP-AO, RPKI) in the alpha release.
+- **Multi-path/ECMP** configuration in the alpha release.
+- **IPv4 primary.** The alpha implementation targets IPv6-only deployments. IPv4 address family is supported in configuration but the route syncer programs IPv6 unicast routes only.
+
+---
+
+## Proposal
+
+### Developer Experience
+
+A platform operator declaring a BGP speaker, two endpoints, and a mesh peering policy:
+
+```bash
+# Declare the local BGP speaker identity
+kubectl apply -f - <<EOF
+apiVersion: bgp.miloapis.com/v1alpha1
+kind: BGPConfiguration
+metadata:
+  name: default
+spec:
+  asNumber: 65001
+  listenPort: 1790
+  routerIDSource: NodeIP
+EOF
+
+# Declare two endpoints (normally created by the node auto-peer operator)
+kubectl apply -f - <<EOF
+apiVersion: bgp.miloapis.com/v1alpha1
+kind: BGPEndpoint
+metadata:
+  name: node-a
+  labels:
+    topology.example.com/region: us-east
+spec:
+  address: "2001:db8::1"
+  asNumber: 65001
+---
+apiVersion: bgp.miloapis.com/v1alpha1
+kind: BGPEndpoint
+metadata:
+  name: node-b
+  labels:
+    topology.example.com/region: us-east
+spec:
+  address: "2001:db8::2"
+  asNumber: 65001
+EOF
+
+# Automate peering — mesh within the region
+kubectl apply -f - <<EOF
+apiVersion: bgp.miloapis.com/v1alpha1
+kind: BGPPeeringPolicy
+metadata:
+  name: us-east-mesh
+spec:
+  selector:
+    matchLabels:
+      topology.example.com/region: us-east
+  mode: mesh
+EOF
+```
+
+Inspect session state:
+
+```bash
+kubectl get bgpsessions
+# NAME               LOCAL    REMOTE    SESSION       RX PREFIXES
+# node-a--node-b     node-a   node-b    Established   4
+```
+
+Inspect all resources in the API group:
+
+```bash
+kubectl get bgpconfigurations,bgpendpoints,bgpsessions,bgppeeringpolicies,bgpadvertisements,bgproutepolicies
+```
+
+### Resource Model
+
+The API defines six resources in `v1alpha1`. Two additional VPN resources (`BGPVPN`, `BGPVPNRoute`) are planned for a future release.
+
+| Resource | Kind | Short Name | Scope | Purpose |
+|----------|------|------------|-------|---------|
+| `bgpconfigurations` | `BGPConfiguration` | `bgpconfig` | Cluster | Local speaker identity (AS, port, router ID) |
+| `bgpendpoints` | `BGPEndpoint` | `bgpep` | Cluster | Self-advertisement ("I exist at this address") |
+| `bgpsessions` | `BGPSession` | `bgpsess` | Cluster | Peering relationship between two endpoints |
+| `bgppeeringpolicies` | `BGPPeeringPolicy` | `bgppp` | Cluster | Automates session creation via label selectors |
+| `bgpadvertisements` | `BGPAdvertisement` | `bgpadvert` | Cluster | Prefix advertisement (phase 2 active) |
+| `bgproutepolicies` | `BGPRoutePolicy` | `bgprp` | Cluster | Import/export filtering rules (phase 2 active) |
+
+All resources are cluster-scoped because BGP topology spans the cluster boundary.
+
+**Resource relationships:**
+
+```
+BGPPeeringPolicy
+  └─ selects BGPEndpoints (via .spec.selector)
+       └─ creates BGPSessions (one per endpoint pair)
+
+BGPConfiguration   ─── configures ──→  GoBGP speaker
+BGPSession         ─── programs ────→  GoBGP peer (AddPeer/UpdatePeer)
+BGPAdvertisement   ─── injects ─────→  GoBGP RIB (AddPath)
+BGPRoutePolicy     ─── applies ─────→  GoBGP policy table
+```
+
+### Three-Layer Architecture
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│  Layer 1: CRD Producers                                      │
+│                                                               │
+│  Node Auto-Peer Operator  ──┐                                │
+│  Cluster Discovery          ├──→  BGPEndpoint resources      │
+│  Platform Operator (human)  │    BGPPeeringPolicy resources  │
+│  Automation system        ──┘    BGPAdvertisement resources  │
+└───────────────────────────────────┬─────────────────────────┘
+                                    │ Kubernetes API
+┌───────────────────────────────────▼─────────────────────────┐
+│  Layer 2: BGP Controller (this project)                       │
+│                                                               │
+│  ConfigReconciler      ──→  GoBGP SetBgp (AS, RouterID)      │
+│  SessionReconciler     ──→  GoBGP AddPeer/UpdatePeer/DelPeer │
+│  PeeringPolicyReconciler ─→  Creates/deletes BGPSession CRDs │
+│  AdvertisementReconciler ─→  GoBGP AddPath/DeletePath        │
+│  RoutePolicyReconciler  ──→  GoBGP AddPolicy/DeletePolicy    │
+│  StatusPoller (10s)     ──→  Updates BGPSession.status       │
+│  HealthWatcher (5s)     ──→  Detects GoBGP restart           │
+└───────────────────────────────────┬─────────────────────────┘
+                                    │ gRPC (127.0.0.1:50051)
+┌───────────────────────────────────▼─────────────────────────┐
+│  GoBGP Sidecar (per-node DaemonSet pod)                      │
+│                                                               │
+│  BGP FSM, RIB, route selection                               │
+│  WatchEvent stream ──→ Route Syncer ──→ netlink (proto 196) │
+└─────────────────────────────────────────────────────────────┘
+```
+
+The controller is **topology-agnostic by design**. It does not know which BGPSession belongs to which node, or whether two endpoints are in the same cluster. It processes every BGPSession resource and programs the local GoBGP instance for sessions where `spec.localEndpoint` matches the value passed to `--local-endpoint` at startup.
+
+---
+
+## Design Details
+
+### Controller Architecture
+
+The controller runs as a DaemonSet — one pod per node — alongside a GoBGP sidecar container. Each instance:
+
+1. Connects to its local GoBGP sidecar via gRPC at `127.0.0.1:50051` (configurable via `--gobgp-addr`).
+2. Starts a controller-runtime manager with five reconcilers.
+3. Starts three background goroutines: health watcher, status poller, and route watcher.
+
+Each reconciler is responsible for one CRD kind:
+
+| Reconciler | CRD | GoBGP Operation |
+|------------|-----|-----------------|
+| `ConfigReconciler` | `BGPConfiguration` | `SetBgp` (global AS and router ID) |
+| `SessionReconciler` | `BGPSession` | `AddPeer` / `UpdatePeer` / `DeletePeer` |
+| `PeeringPolicyReconciler` | `BGPPeeringPolicy` | Creates/deletes `BGPSession` CRDs (no direct GoBGP calls) |
+| `AdvertisementReconciler` | `BGPAdvertisement` | `AddPath` / `DeletePath` |
+| `RoutePolicyReconciler` | `BGPRoutePolicy` | `AddPolicy` / `DeletePolicy` |
+
+The `PeeringPolicyReconciler` is a pure Kubernetes operator — it reads endpoints and writes sessions. The session-to-GoBGP reconciliation is handled by the `SessionReconciler` in a separate reconcile loop.
+
+### GoBGP Sidecar Pattern
+
+GoBGP runs as a sidecar container in the same DaemonSet pod as the controller. Communication is over gRPC on localhost. This pattern:
+
+- Eliminates network policy concerns between controller and BGP daemon.
+- Allows independent restart of GoBGP without restarting the controller.
+- Scopes GoBGP state to one node — each node has its own BGP speaker with its own peers.
+
+GoBGP is **treated as stateless** from the controller's perspective. All desired BGP state is in the CRDs. If GoBGP restarts, the controller's `FullReconcile` re-applies the complete desired state.
+
+The controller connects to GoBGP at startup with up to 30 retry attempts (2-second interval), tolerating slow GoBGP startup.
+
+### Session Lifecycle
+
+When a `BGPSession` is created or updated:
+
+1. The `SessionReconciler` reads `spec.localEndpoint` and `spec.remoteEndpoint` (both `BGPEndpoint` names).
+2. It resolves both endpoints to get IP addresses and AS numbers.
+3. It calls `buildGoBGPPeer` to construct a `gobgpapi.Peer` struct from the session spec and resolved endpoints.
+4. It calls `AddPeer`; if GoBGP returns "can't overwrite the existing peer" (GoBGP's equivalent of `AlreadyExists`), it falls back to `UpdatePeer`.
+5. On deletion, it calls `DeletePeer` using the remote endpoint's address.
+
+The `SessionReconciler` only reconciles sessions where `spec.localEndpoint` matches the controller's `--local-endpoint` flag. Sessions for other nodes are ignored.
+
+Session status is **not updated by the reconciler** — status comes from the status poller (see below).
+
+### Status Polling
+
+A background goroutine polls GoBGP every 10 seconds using `ListPeer` with `EnableAdvertised: true`. For each `BGPSession` resource, it:
+
+1. Resolves `spec.remoteEndpoint` to get the neighbor address GoBGP uses as its key.
+2. Matches the GoBGP peer state by neighbor address.
+3. Updates `status.sessionState`, `status.receivedPrefixes`, `status.advertisedPrefixes`, `status.flapCount`, and `status.lastTransitionTime`.
+4. Sets the `SessionEstablished` condition.
+5. Emits Prometheus metrics.
+
+The polling approach (rather than event-driven) avoids the complexity of managing a long-lived GoBGP event stream for status. The 10-second polling interval means status may lag real session state by up to 10 seconds.
+
+### Resilience and Re-reconciliation
+
+The health watcher goroutine polls GoBGP every 5 seconds via `GetBgp`. When it detects a failure:
+
+1. It closes the stale gRPC connection.
+2. It reconnects with retries.
+3. On successful reconnection, it closes the `reconnectCh` channel (signaling reconcilers) and calls `FullReconcile`.
+
+`FullReconcile` re-applies:
+- All `BGPSession` resources via `AddPeer`/`UpdatePeer`.
+- All `BGPAdvertisement` resources by bumping a `bgp.miloapis.com/reconcile-trigger` annotation, which causes the advertisement reconciler to re-inject all prefixes.
+- All `BGPRoutePolicy` resources similarly.
+
+This ensures GoBGP state is fully consistent with CRDs after any restart.
+
+### Metrics
+
+The controller exposes Prometheus metrics on `:8082` (configurable via `--metrics-addr`):
+
+| Metric | Type | Labels | Description |
+|--------|------|--------|-------------|
+| `bgp_session_state` | Gauge | `session`, `state` | 1 for the active FSM state, 0 for all others |
+| `bgp_received_prefixes_total` | Gauge | `session` | Prefixes received from the remote peer |
+| `bgp_session_flaps_total` | Counter | `session` | Times the session left Established state |
+| `bgp_advertised_prefixes_total` | Gauge | `advertisement` | Prefixes currently in the GoBGP RIB |
+| `bgp_route_policies_applied` | Gauge | `policy` | 1 if the policy is applied to GoBGP |
+
+All standard controller-runtime metrics (reconcile duration, work queue depth, etc.) are also exposed.
+
+---
+
+## User Stories
+
+**As a platform operator**, I want to declare BGP peering topology via `kubectl apply` so that BGP configuration is version-controlled, auditable, and managed with the same tooling as the rest of my infrastructure.
+
+**As a network engineer**, I want to inspect BGP session state with `kubectl get bgpsessions` so that I can diagnose connectivity problems without logging into individual nodes or using vendor-specific CLI tools.
+
+**As an automation system** (node discovery operator, cluster fleet manager), I want to create `BGPEndpoint` resources for each node and have the `BGPPeeringPolicy` controller automatically create the correct sessions, so that topology scales without per-node manual configuration.
+
+**As a multi-cluster operator**, I want to declare eBGP sessions between clusters by creating `BGPSession` resources with endpoints that have different `asNumber` values, without modifying the BGP controller or its configuration.
+
+**As a platform engineer debugging a network outage**, I want to see flap counts and last-transition timestamps on `BGPSession` resources so that I can correlate BGP instability with other events in the cluster.
+
+---
+
+## Drawbacks
+
+**GoBGP sidecar coupling.** The controller is tightly coupled to GoBGP's gRPC API. Replacing GoBGP with another BGP daemon (Bird, FRRouting) would require rewriting the GoBGP client layer.
+
+**Status polling lag.** Session status updates are polled every 10 seconds. In high-frequency flap scenarios, short-lived state transitions may not be captured.
+
+**Session ownership model.** Each controller instance only reconciles sessions where `spec.localEndpoint` matches its own `--local-endpoint`. If a `BGPSession` names a non-existent endpoint as local, it will never be reconciled without operator intervention.
+
+---
+
+## Alternatives Considered
+
+**Embed BGP in the CNI.** This is the Cilium/Calico/MetalLB approach. Rejected because it couples BGP management to the data plane, preventing reuse across networking stacks.
+
+**Use FRRouting instead of GoBGP.** FRR has broader protocol support and wider production deployment. GoBGP was chosen for alpha because its gRPC API is designed for programmatic control, making the controller implementation simpler. FRR can be evaluated as an alternative backend post-alpha.
+
+**Push configuration files instead of gRPC.** Writing GoBGP config files and sending SIGHUP is an alternative to gRPC. Rejected because the gRPC API provides richer status feedback and is the direction GoBGP intends for programmatic use.
+
+**Namespace-scoped resources.** Rejected because BGP topology spans namespaces (and clusters). Cluster-scoped resources reflect the actual topology boundary.

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -3,7 +3,7 @@ status: implementable
 stage: alpha
 ---
 
-# Service Design: Kubernetes-Native BGP Control Plane
+# Service Design: BGP Control Plane
 
 > Last verified: 2026-03-16 against main (initial implementation)
 
@@ -32,7 +32,7 @@ stage: alpha
 
 ## Summary
 
-`datum-cloud/bgp` is a Kubernetes-native BGP control plane that manages BGP topology declaratively via Custom Resource Definitions (CRDs), powered by [GoBGP](https://github.com/osrg/gobgp). The API group is `bgp.miloapis.com/v1alpha1`.
+`datum-cloud/bgp` is a declarative BGP control plane that manages BGP topology via Custom Resource Definitions (CRDs) on any Kubernetes-compatible API server, powered by [GoBGP](https://github.com/osrg/gobgp). It uses the Kubernetes API as a control plane framework — not as a container orchestrator. The controller runs anywhere you have a Kubernetes-compatible API server (full clusters, k3s, KCP, or standalone kube-apiserver). No kubelet, scheduler, CNI, or pod networking is required. The API group is `bgp.miloapis.com/v1alpha1`.
 
 Resources represent things — endpoints, sessions, policies — not imperative commands. The controller is topology-agnostic: it reconciles CRDs into GoBGP gRPC calls without embedded knowledge of nodes, clusters, borders, or network topology. Any system that can create Kubernetes objects can produce BGP topology by writing BGP CRDs.
 


### PR DESCRIPTION
## Summary

- Adds `docs/design/README.md`: service design document covering motivation, goals/non-goals, three-layer architecture, controller internals, and user stories
- Adds `docs/api/README.md`: complete API reference for all six `bgp.miloapis.com/v1alpha1` CRDs with field tables, defaults, validation, conditions, and example YAML
- Updates `README.md`: adds architecture diagram, CRD table with short names, four-step quick start, and links to the new docs

All API field documentation was verified against the Go type definitions in `api/v1alpha1/`. All controller behavior documented in the design doc was verified against `internal/controller/`.

## What is documented

**Service Design** (`docs/design/README.md`):
- Summary and motivation: why decouple BGP topology management from the data plane
- Goals and non-goals (alpha scope)
- Developer experience section with kubectl examples early
- Three-layer architecture diagram (CRD producers → controller → GoBGP/kernel)
- Controller architecture: five reconcilers, three background goroutines
- GoBGP sidecar pattern and stateless treatment of GoBGP
- Session lifecycle (AddPeer/UpdatePeer flow)
- Status polling model (10-second poll interval, why polling not streaming)
- Resilience: health watcher, FullReconcile on GoBGP restart
- Prometheus metrics table
- User stories (platform operator, network engineer, automation system, multi-cluster operator)
- Drawbacks and alternatives considered

**API Reference** (`docs/api/README.md`):
- All six CRDs: BGPConfiguration, BGPEndpoint, BGPSession, BGPPeeringPolicy, BGPAdvertisement, BGPRoutePolicy
- Field tables with types, defaults, validation constraints, required/optional
- Status fields and all condition types with meanings
- Realistic YAML examples for each resource (including route-reflector sessions, eBGP multi-hop)
- Note on planned BGPVPN/BGPVPNRoute resources
- Common patterns: labeling conventions, naming conventions, verification commands

## Test plan

- [ ] Verify `docs/design/README.md` renders correctly in GitHub (table of contents anchors, code blocks, callout boxes)
- [ ] Verify `docs/api/README.md` field tables render correctly
- [ ] Spot-check field documentation against `api/v1alpha1/*_types.go` — particularly defaults (`listenPort: 1790`, `holdTime: 90`, `keepaliveTime: 30`, `mode: mesh`)
- [ ] Verify short names match kubebuilder markers in type files (`bgpconfig`, `bgpep`, `bgpsess`, `bgppp`, `bgpadvert`, `bgprp`)
- [ ] Verify status condition type constants match type files (`SpeakerReady`, `SessionEstablished`, `Configured`, `InvalidConfig`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)