### PR TITLE
Add comprehensive E2E test suite

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,106 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+env:
+  GO_VERSION: '1.24'
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: ${{ env.GO_VERSION }}
+
+      - name: Build
+        run: go build ./...
+
+      - name: Vet
+        run: go vet ./...
+
+      - name: Unit Tests
+        run: go test ./...
+
+  e2e:
+    name: E2E Tests
+    runs-on: ubuntu-latest
+    needs: build
+    timeout-minutes: 30
+    env:
+      KUBECONFIG: ${{ github.workspace }}/test/e2e/.kubeconfig
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: ${{ env.GO_VERSION }}
+
+      - name: Install kind
+        run: |
+          go install sigs.k8s.io/kind@latest
+          kind version
+
+      - name: Install task
+        uses: arduino/setup-task@v2
+        with:
+          version: 3.x
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Install chainsaw
+        run: |
+          CHAINSAW_VERSION=v0.2.12
+          curl -sSL "https://github.com/kyverno/chainsaw/releases/download/${CHAINSAW_VERSION}/chainsaw_linux_amd64.tar.gz" \
+            | tar -xz -C /usr/local/bin chainsaw
+          chainsaw version
+
+      - name: Install helm
+        uses: azure/setup-helm@v4
+        with:
+          version: v3.17.0
+
+      - name: Run E2E suite
+        working-directory: test/e2e
+        run: task default
+
+      - name: Collect logs on failure
+        if: failure()
+        run: |
+          echo "=== Pods in bgp-system ==="
+          kubectl get pods -n bgp-system -o wide || true
+          echo ""
+          echo "=== Logs from bgp-system pods ==="
+          kubectl logs -n bgp-system -l app.kubernetes.io/name=bgp --all-containers=true --prefix=true 2>/dev/null || true
+          echo ""
+          echo "=== Events in bgp-system ==="
+          kubectl get events -n bgp-system --sort-by='.lastTimestamp' || true
+          echo ""
+          echo "=== Events in kube-system ==="
+          kubectl get events -n kube-system --sort-by='.lastTimestamp' | tail -40 || true
+          echo ""
+          echo "=== Node status ==="
+          kubectl get nodes -o wide || true
+          echo ""
+          echo "=== BGP resources ==="
+          kubectl get bgpconfigurations,bgpsessions,bgpendpoints,bgppeeringpolicies,bgpadvertisements,bgproutepolicies --all-namespaces 2>/dev/null || true
+
+      - name: Upload logs artifact
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: e2e-logs-${{ github.run_id }}
+          path: |
+            test/e2e/.kubeconfig
+          retention-days: 7
+
+      - name: Delete kind cluster
+        if: always()
+        run: kind delete cluster --name bgp-e2e || true

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -1,0 +1,53 @@
+name: Docker
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-push:
+    name: Build and Push
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Log in to Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            type=sha
+
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: build/Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          platforms: linux/amd64,linux/arm64
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,7 @@ bin/
 *.exe
 *.test
 *.out
+
+# E2E test artifacts
+test/e2e/.kubeconfig
+test/e2e/.kubeconfig.lock

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,34 @@
+# BGP operator Makefile
+
+GOBIN ?= $(shell pwd)/bin
+
+.PHONY: build
+build:
+	go build ./...
+
+.PHONY: test
+test:
+	go test ./...
+
+.PHONY: lint
+lint:
+	golangci-lint run ./...
+
+.PHONY: generate
+generate:
+	controller-gen object:headerFile="hack/boilerplate.go.txt" paths="./..."
+
+.PHONY: manifests
+manifests:
+	controller-gen crd paths="./api/..." output:crd:artifacts:config=config/crd
+
+# --- E2E ---
+
+.PHONY: test-e2e
+test-e2e:
+	cd test/e2e && task default
+
+# Install chainsaw test runner
+.PHONY: chainsaw
+chainsaw:
+	GOBIN=$(GOBIN) go install github.com/kyverno/chainsaw@v0.2.12

--- a/test/e2e/Taskfile.yml
+++ b/test/e2e/Taskfile.yml
@@ -1,0 +1,152 @@
+version: '3'
+
+vars:
+  CLUSTER_NAME: bgp-e2e
+  KIND_CONFIG: "{{.TASKFILE_DIR}}/kind-config.yaml"
+  KIND_IMAGE: kindest/node:v1.34.0
+  KUBECONFIG: "{{.TASKFILE_DIR}}/.kubeconfig"
+  REPO_ROOT: "{{.TASKFILE_DIR}}/../.."
+  BGP_IMG: ghcr.io/datum-cloud/bgp:e2e-local
+  GOBGPD_IMG: gobgpd:e2e-local
+
+tasks:
+  default:
+    desc: Run the full E2E suite (setup, build, deploy, test, teardown)
+    cmds:
+      - task: cluster-create
+      - task: images-build
+      - task: images-load
+      - task: deploy
+      - task: test
+      - task: cluster-delete
+
+  cluster-create:
+    desc: Create the kind cluster for E2E tests
+    cmds:
+      # Increase inotify limits for file-watching components
+      - sudo sysctl -w fs.inotify.max_user_instances=8192 fs.inotify.max_user_watches=524288 || true
+      - kind create cluster
+          --name {{.CLUSTER_NAME}}
+          --config {{.KIND_CONFIG}}
+          --image {{.KIND_IMAGE}}
+          --kubeconfig {{.KUBECONFIG}}
+          --wait 120s
+      # In Docker-outside-of-Docker devcontainers the API server port binding maps
+      # to the host machine, not the devcontainer. Patch the kubeconfig server URL
+      # to use the control-plane container's IP on the kind Docker bridge network.
+      - |
+        CP_IP=$(docker inspect {{.CLUSTER_NAME}}-control-plane \
+          --format '{{`{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}`}}' 2>/dev/null | head -1)
+        if [ -n "$CP_IP" ]; then
+          KUBECONFIG={{.KUBECONFIG}} kubectl config set-cluster kind-{{.CLUSTER_NAME}} \
+            --server=https://${CP_IP}:6443
+        fi
+      # Connect the devcontainer to the kind network so it can reach cluster IPs
+      - |
+        CONTAINER_ID=$(cat /proc/self/cgroup 2>/dev/null | grep -o 'docker/[a-f0-9]*' | head -1 | cut -d/ -f2 || hostname)
+        docker network connect kind "${CONTAINER_ID}" 2>/dev/null || true
+    status:
+      - kind get clusters | grep -q {{.CLUSTER_NAME}}
+
+  cluster-delete:
+    desc: Delete the E2E kind cluster
+    cmds:
+      - kind delete cluster --name {{.CLUSTER_NAME}}
+      - rm -f {{.KUBECONFIG}}
+
+  images-build:
+    desc: Build bgp operator and gobgpd images
+    cmds:
+      - task: images-build-bgp
+      - task: images-build-gobgpd
+
+  images-build-bgp:
+    desc: Build the bgp operator image
+    dir: "{{.REPO_ROOT}}"
+    cmds:
+      - docker build -t {{.BGP_IMG}} -f build/Dockerfile .
+
+  images-build-gobgpd:
+    desc: Build the gobgpd sidecar image
+    cmds:
+      - |
+        docker build --output type=docker -t {{.GOBGPD_IMG}} - <<'DOCKERFILE'
+        FROM golang:1.24-alpine AS build
+        RUN apk add --no-cache git
+        RUN go install github.com/osrg/gobgp/v3/cmd/gobgpd@v3.37.0
+        FROM alpine:3.19
+        COPY --from=build /go/bin/gobgpd /usr/local/bin/gobgpd
+        ENTRYPOINT ["gobgpd"]
+        DOCKERFILE
+
+  images-load:
+    desc: Load locally-built images into the kind cluster
+    cmds:
+      - kind load docker-image {{.BGP_IMG}} --name {{.CLUSTER_NAME}}
+      - kind load docker-image {{.GOBGPD_IMG}} --name {{.CLUSTER_NAME}}
+
+  deploy:
+    desc: Deploy all BGP system components in order
+    cmds:
+      - task: deploy-cilium
+      - task: deploy-crds
+      - task: deploy-bgp-operator
+      - task: deploy-bgp-config
+
+  deploy-cilium:
+    desc: Install Cilium as the base CNI for pod networking
+    cmds:
+      - helm repo add cilium https://helm.cilium.io/ 2>/dev/null || true
+      - helm repo update cilium
+      - KUBECONFIG={{.KUBECONFIG}} helm upgrade --install cilium cilium/cilium
+          --version 1.17.3
+          --namespace kube-system
+          --set cni.exclusive=false
+          --set ipam.mode=kubernetes
+          --set kubeProxyReplacement=false
+          --set ipv6.enabled=true
+          --wait
+          --timeout 3m
+      - KUBECONFIG={{.KUBECONFIG}} kubectl -n kube-system wait
+          --for=condition=Ready
+          pod -l app.kubernetes.io/name=cilium-agent
+          --timeout=180s
+
+  deploy-crds:
+    desc: Apply BGP CRDs and wait for Established
+    cmds:
+      - KUBECONFIG={{.KUBECONFIG}} kubectl apply -k {{.REPO_ROOT}}/config/crd
+      - KUBECONFIG={{.KUBECONFIG}} kubectl wait
+          --for=condition=Established
+          crd/bgpconfigurations.bgp.miloapis.com
+          crd/bgpsessions.bgp.miloapis.com
+          crd/bgpendpoints.bgp.miloapis.com
+          crd/bgppeeringpolicies.bgp.miloapis.com
+          crd/bgpadvertisements.bgp.miloapis.com
+          crd/bgproutepolicies.bgp.miloapis.com
+          --timeout=60s
+
+  deploy-bgp-operator:
+    desc: Deploy BGP operator DaemonSet with gobgpd sidecar
+    cmds:
+      # Apply the deploy kustomization (namespace, RBAC, ConfigMap, DaemonSet)
+      # using an overlay that sets the e2e-local image tags and LOCAL_ENDPOINT.
+      - KUBECONFIG={{.KUBECONFIG}} kubectl apply -k {{.TASKFILE_DIR}}/overlay
+      - KUBECONFIG={{.KUBECONFIG}} kubectl -n bgp-system wait
+          --for=condition=Ready
+          pod -l app.kubernetes.io/name=bgp
+          --timeout=120s
+
+  deploy-bgp-config:
+    desc: Apply the default BGPConfiguration
+    cmds:
+      - KUBECONFIG={{.KUBECONFIG}} kubectl apply -f {{.TASKFILE_DIR}}/fixtures/bgpconfiguration-default.yaml
+
+  test:
+    desc: Run the Chainsaw E2E test suite
+    env:
+      KUBECONFIG: "{{.KUBECONFIG}}"
+    cmds:
+      - chainsaw test
+          --test-dir {{.TASKFILE_DIR}}/tests
+          --config {{.TASKFILE_DIR}}/chainsaw-config.yaml

--- a/test/e2e/chainsaw-config.yaml
+++ b/test/e2e/chainsaw-config.yaml
@@ -1,0 +1,10 @@
+apiVersion: chainsaw.kyverno.io/v1alpha2
+kind: Configuration
+metadata:
+  name: bgp-e2e
+spec:
+  timeouts:
+    apply: 2m
+    assert: 5m
+    delete: 2m
+    exec: 2m

--- a/test/e2e/fixtures/bgpconfiguration-default.yaml
+++ b/test/e2e/fixtures/bgpconfiguration-default.yaml
@@ -1,0 +1,11 @@
+apiVersion: bgp.miloapis.com/v1alpha1
+kind: BGPConfiguration
+metadata:
+  name: default
+spec:
+  asNumber: 65000
+  listenPort: 1790
+  routerIDSource: NodeIP
+  addressFamilies:
+    - afi: IPv6
+      safi: Unicast

--- a/test/e2e/kind-config.yaml
+++ b/test/e2e/kind-config.yaml
@@ -1,0 +1,17 @@
+apiVersion: kind.x-k8s.io/v1alpha4
+kind: Cluster
+name: bgp-e2e
+nodes:
+  - role: control-plane
+  - role: worker
+    labels:
+      topology.kubernetes.io/region: region1
+  - role: worker
+    labels:
+      topology.kubernetes.io/region: region2
+  - role: worker
+    labels:
+      topology.kubernetes.io/region: region3
+networking:
+  disableDefaultCNI: true
+  ipFamily: dual

--- a/test/e2e/overlay/kustomization.yaml
+++ b/test/e2e/overlay/kustomization.yaml
@@ -1,0 +1,32 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+# Base deploy resources: namespace, RBAC, ConfigMap, DaemonSet
+resources:
+  - ../../../config/deploy
+
+# Override image tags for local e2e builds
+images:
+  - name: ghcr.io/datum-cloud/bgp
+    newTag: e2e-local
+  - name: gobgpd
+    newName: gobgpd
+    newTag: e2e-local
+
+# Patch to set LOCAL_ENDPOINT to "node-$(NODE_NAME)" so each DaemonSet pod
+# registers its endpoint under the correct node-scoped name.
+patches:
+  - patch: |-
+      apiVersion: apps/v1
+      kind: DaemonSet
+      metadata:
+        name: bgp
+        namespace: bgp-system
+      spec:
+        template:
+          spec:
+            containers:
+              - name: bgp
+                env:
+                  - name: LOCAL_ENDPOINT
+                    value: "node-$(NODE_NAME)"

--- a/test/e2e/tests/bgp-advertisement/chainsaw-test.yaml
+++ b/test/e2e/tests/bgp-advertisement/chainsaw-test.yaml
@@ -1,0 +1,196 @@
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: bgp-advertisement
+spec:
+  description: >
+    Verify that BGPAdvertisement resources inject prefixes into the GoBGP RIB
+    and that withdrawal removes them. Requires at least one BGP session to be
+    Established so that RIB adjacency is available.
+  steps:
+    - name: setup-endpoints-and-peering
+      try:
+        - script:
+            env:
+              - name: KUBECONFIG
+                value: ($env.KUBECONFIG)
+            content: |
+              set -e
+              get_ipv6() {
+                kubectl get node "$1" \
+                  -o jsonpath='{range .status.addresses[?(@.type=="InternalIP")]}{.address}{"\n"}{end}' \
+                  | grep ':' | head -1
+              }
+              W1=$(get_ipv6 bgp-e2e-worker)
+              W2=$(get_ipv6 bgp-e2e-worker2)
+
+              kubectl apply -f - <<EOF
+              apiVersion: bgp.miloapis.com/v1alpha1
+              kind: BGPEndpoint
+              metadata:
+                name: node-bgp-e2e-worker-adv
+                labels:
+                  e2e-test: bgp-advertisement
+              spec:
+                address: "${W1}"
+                asNumber: 65000
+                addressFamilies:
+                  - afi: IPv6
+                    safi: Unicast
+              ---
+              apiVersion: bgp.miloapis.com/v1alpha1
+              kind: BGPEndpoint
+              metadata:
+                name: node-bgp-e2e-worker2-adv
+                labels:
+                  e2e-test: bgp-advertisement
+              spec:
+                address: "${W2}"
+                asNumber: 65000
+                addressFamilies:
+                  - afi: IPv6
+                    safi: Unicast
+              ---
+              apiVersion: bgp.miloapis.com/v1alpha1
+              kind: BGPPeeringPolicy
+              metadata:
+                name: e2e-adv-mesh
+              spec:
+                selector:
+                  matchLabels:
+                    e2e-test: bgp-advertisement
+                mode: mesh
+                sessionTemplate:
+                  holdTime: 30
+                  keepaliveTime: 10
+              EOF
+
+    - name: wait-for-session-established
+      try:
+        - script:
+            env:
+              - name: KUBECONFIG
+                value: ($env.KUBECONFIG)
+            content: |
+              set -e
+              ATTEMPTS=0
+              while [ "$ATTEMPTS" -lt 60 ]; do
+                STATE=$(kubectl get bgpsessions \
+                  -o jsonpath='{range .items[*]}{.status.sessionState}{"\n"}{end}' \
+                  | grep -c "^Established$" || true)
+                [ "$STATE" -ge 1 ] && break
+                ATTEMPTS=$((ATTEMPTS+1))
+                sleep 5
+              done
+              if [ "$STATE" -lt 1 ]; then
+                echo "ERROR: no BGP sessions reached Established"
+                kubectl get bgpsessions -o wide
+                exit 1
+              fi
+              echo "OK: BGP session Established"
+
+    - name: create-bgp-advertisement
+      try:
+        - apply:
+            resource:
+              apiVersion: bgp.miloapis.com/v1alpha1
+              kind: BGPAdvertisement
+              metadata:
+                name: e2e-test-prefix
+              spec:
+                prefixes:
+                  - "2001:db8:e2e::/48"
+
+    - name: assert-advertisement-condition
+      try:
+        - assert:
+            resource:
+              apiVersion: bgp.miloapis.com/v1alpha1
+              kind: BGPAdvertisement
+              metadata:
+                name: e2e-test-prefix
+              status:
+                (advertisedPrefixCount >= `1`): true
+
+    - name: assert-prefix-in-gobgp-rib
+      try:
+        - script:
+            env:
+              - name: KUBECONFIG
+                value: ($env.KUBECONFIG)
+            content: |
+              set -e
+              # Get any bgp pod name to exec into gobgpd
+              POD=$(kubectl -n bgp-system get pod \
+                -l app.kubernetes.io/name=bgp \
+                -o jsonpath='{.items[0].metadata.name}')
+              echo "Checking GoBGP RIB in pod: $POD"
+
+              ATTEMPTS=0
+              FOUND=0
+              while [ "$FOUND" -eq 0 ] && [ "$ATTEMPTS" -lt 30 ]; do
+                OUTPUT=$(kubectl -n bgp-system exec "$POD" -c gobgpd -- \
+                  gobgp global rib -a ipv6 2>/dev/null || true)
+                echo "$OUTPUT" | grep -q "2001:db8:e2e::" && FOUND=1 || true
+                ATTEMPTS=$((ATTEMPTS+1))
+                [ "$FOUND" -eq 0 ] && sleep 5
+              done
+
+              if [ "$FOUND" -eq 0 ]; then
+                echo "ERROR: prefix 2001:db8:e2e::/48 not found in GoBGP RIB"
+                kubectl -n bgp-system exec "$POD" -c gobgpd -- \
+                  gobgp global rib -a ipv6 || true
+                exit 1
+              fi
+              echo "OK: prefix 2001:db8:e2e::/48 found in GoBGP RIB"
+
+    - name: delete-advertisement-and-verify-withdrawal
+      try:
+        - delete:
+            ref:
+              apiVersion: bgp.miloapis.com/v1alpha1
+              kind: BGPAdvertisement
+              name: e2e-test-prefix
+        - script:
+            env:
+              - name: KUBECONFIG
+                value: ($env.KUBECONFIG)
+            content: |
+              set -e
+              POD=$(kubectl -n bgp-system get pod \
+                -l app.kubernetes.io/name=bgp \
+                -o jsonpath='{.items[0].metadata.name}')
+              echo "Verifying prefix withdrawn from GoBGP RIB in pod: $POD"
+
+              ATTEMPTS=0
+              STILL_PRESENT=1
+              while [ "$STILL_PRESENT" -eq 1 ] && [ "$ATTEMPTS" -lt 30 ]; do
+                OUTPUT=$(kubectl -n bgp-system exec "$POD" -c gobgpd -- \
+                  gobgp global rib -a ipv6 2>/dev/null || true)
+                echo "$OUTPUT" | grep -q "2001:db8:e2e::" && STILL_PRESENT=1 || STILL_PRESENT=0
+                ATTEMPTS=$((ATTEMPTS+1))
+                [ "$STILL_PRESENT" -eq 1 ] && sleep 5
+              done
+
+              if [ "$STILL_PRESENT" -eq 1 ]; then
+                echo "ERROR: prefix 2001:db8:e2e::/48 still in GoBGP RIB after deletion"
+                exit 1
+              fi
+              echo "OK: prefix 2001:db8:e2e::/48 withdrawn from GoBGP RIB"
+
+      finally:
+        - delete:
+            ref:
+              apiVersion: bgp.miloapis.com/v1alpha1
+              kind: BGPPeeringPolicy
+              name: e2e-adv-mesh
+        - delete:
+            ref:
+              apiVersion: bgp.miloapis.com/v1alpha1
+              kind: BGPEndpoint
+              name: node-bgp-e2e-worker-adv
+        - delete:
+            ref:
+              apiVersion: bgp.miloapis.com/v1alpha1
+              kind: BGPEndpoint
+              name: node-bgp-e2e-worker2-adv

--- a/test/e2e/tests/bgp-peering/chainsaw-test.yaml
+++ b/test/e2e/tests/bgp-peering/chainsaw-test.yaml
@@ -1,0 +1,214 @@
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: bgp-peering
+spec:
+  description: >
+    Verify that BGPEndpoints + BGPPeeringPolicy in mesh mode produce BGPSession
+    resources that reach Established state.
+  steps:
+    - name: resolve-worker-node-ips
+      try:
+        # Capture IPv6 addresses of the three worker nodes into a ConfigMap so
+        # subsequent steps can reference them as endpoint addresses. kind worker
+        # nodes are named bgp-e2e-worker, bgp-e2e-worker2, bgp-e2e-worker3.
+        - script:
+            env:
+              - name: KUBECONFIG
+                value: ($env.KUBECONFIG)
+            content: |
+              set -e
+              get_ipv6() {
+                kubectl get node "$1" \
+                  -o jsonpath='{range .status.addresses[?(@.type=="InternalIP")]}{.address}{"\n"}{end}' \
+                  | grep ':' | head -1
+              }
+              W1=$(get_ipv6 bgp-e2e-worker)
+              W2=$(get_ipv6 bgp-e2e-worker2)
+              W3=$(get_ipv6 bgp-e2e-worker3)
+              echo "worker1=$W1 worker2=$W2 worker3=$W3"
+
+              # Write resolved IPs into a scratch ConfigMap for assertion reference
+              kubectl create configmap bgp-e2e-node-ips \
+                --from-literal=worker1="${W1}" \
+                --from-literal=worker2="${W2}" \
+                --from-literal=worker3="${W3}" \
+                --dry-run=client -o yaml | kubectl apply -f -
+
+    - name: create-bgp-endpoints
+      try:
+        - script:
+            env:
+              - name: KUBECONFIG
+                value: ($env.KUBECONFIG)
+            content: |
+              set -e
+              get_ipv6() {
+                kubectl get node "$1" \
+                  -o jsonpath='{range .status.addresses[?(@.type=="InternalIP")]}{.address}{"\n"}{end}' \
+                  | grep ':' | head -1
+              }
+              W1=$(get_ipv6 bgp-e2e-worker)
+              W2=$(get_ipv6 bgp-e2e-worker2)
+              W3=$(get_ipv6 bgp-e2e-worker3)
+
+              kubectl apply -f - <<EOF
+              apiVersion: bgp.miloapis.com/v1alpha1
+              kind: BGPEndpoint
+              metadata:
+                name: node-bgp-e2e-worker
+                labels:
+                  e2e-test: bgp-peering
+                  topology.kubernetes.io/region: region1
+              spec:
+                address: "${W1}"
+                asNumber: 65000
+                addressFamilies:
+                  - afi: IPv6
+                    safi: Unicast
+              ---
+              apiVersion: bgp.miloapis.com/v1alpha1
+              kind: BGPEndpoint
+              metadata:
+                name: node-bgp-e2e-worker2
+                labels:
+                  e2e-test: bgp-peering
+                  topology.kubernetes.io/region: region2
+              spec:
+                address: "${W2}"
+                asNumber: 65000
+                addressFamilies:
+                  - afi: IPv6
+                    safi: Unicast
+              ---
+              apiVersion: bgp.miloapis.com/v1alpha1
+              kind: BGPEndpoint
+              metadata:
+                name: node-bgp-e2e-worker3
+                labels:
+                  e2e-test: bgp-peering
+                  topology.kubernetes.io/region: region3
+              spec:
+                address: "${W3}"
+                asNumber: 65000
+                addressFamilies:
+                  - afi: IPv6
+                    safi: Unicast
+              EOF
+
+    - name: create-peering-policy-mesh
+      try:
+        - apply:
+            resource:
+              apiVersion: bgp.miloapis.com/v1alpha1
+              kind: BGPPeeringPolicy
+              metadata:
+                name: e2e-mesh
+              spec:
+                selector:
+                  matchLabels:
+                    e2e-test: bgp-peering
+                mode: mesh
+                sessionTemplate:
+                  holdTime: 30
+                  keepaliveTime: 10
+
+    - name: assert-policy-matched-endpoints
+      try:
+        - assert:
+            resource:
+              apiVersion: bgp.miloapis.com/v1alpha1
+              kind: BGPPeeringPolicy
+              metadata:
+                name: e2e-mesh
+              status:
+                # 3 endpoints selected by the label selector
+                (matchedEndpoints == `3`): true
+
+    - name: assert-sessions-created
+      try:
+        # Mesh of 3 endpoints creates 3 sessions (N*(N-1)/2)
+        - assert:
+            resource:
+              apiVersion: bgp.miloapis.com/v1alpha1
+              kind: BGPPeeringPolicy
+              metadata:
+                name: e2e-mesh
+              status:
+                (activeSessions == `3`): true
+
+    - name: assert-sessions-established
+      try:
+        # Each BGPSession should reach Established state.
+        # We assert via sessionState field on all sessions owned by the policy.
+        - script:
+            env:
+              - name: KUBECONFIG
+                value: ($env.KUBECONFIG)
+            content: |
+              set -e
+              # Wait up to 5 minutes (chainsaw assert timeout) for all sessions
+              ESTABLISHED=0
+              ATTEMPTS=0
+              while [ "$ESTABLISHED" -lt 3 ] && [ "$ATTEMPTS" -lt 60 ]; do
+                ESTABLISHED=$(kubectl get bgpsessions \
+                  -o jsonpath='{range .items[*]}{.status.sessionState}{"\n"}{end}' \
+                  | grep -c "^Established$" || true)
+                ATTEMPTS=$((ATTEMPTS+1))
+                [ "$ESTABLISHED" -lt 3 ] && sleep 5
+              done
+              if [ "$ESTABLISHED" -lt 3 ]; then
+                echo "ERROR: only $ESTABLISHED/3 sessions reached Established"
+                kubectl get bgpsessions -o wide
+                exit 1
+              fi
+              echo "OK: $ESTABLISHED/3 sessions are Established"
+
+      finally:
+        - delete:
+            ref:
+              apiVersion: bgp.miloapis.com/v1alpha1
+              kind: BGPPeeringPolicy
+              name: e2e-mesh
+        - delete:
+            ref:
+              apiVersion: bgp.miloapis.com/v1alpha1
+              kind: BGPEndpoint
+              name: node-bgp-e2e-worker
+        - delete:
+            ref:
+              apiVersion: bgp.miloapis.com/v1alpha1
+              kind: BGPEndpoint
+              name: node-bgp-e2e-worker2
+        - delete:
+            ref:
+              apiVersion: bgp.miloapis.com/v1alpha1
+              kind: BGPEndpoint
+              name: node-bgp-e2e-worker3
+        - delete:
+            ref:
+              apiVersion: v1
+              kind: ConfigMap
+              name: bgp-e2e-node-ips
+
+    - name: assert-sessions-cleaned-up
+      try:
+        - script:
+            env:
+              - name: KUBECONFIG
+                value: ($env.KUBECONFIG)
+            content: |
+              set -e
+              ATTEMPTS=0
+              COUNT=1
+              while [ "$COUNT" -gt 0 ] && [ "$ATTEMPTS" -lt 30 ]; do
+                COUNT=$(kubectl get bgpsessions --no-headers 2>/dev/null | wc -l || echo 0)
+                ATTEMPTS=$((ATTEMPTS+1))
+                [ "$COUNT" -gt 0 ] && sleep 5
+              done
+              if [ "$COUNT" -gt 0 ]; then
+                echo "ERROR: $COUNT BGPSessions still exist after policy deletion"
+                kubectl get bgpsessions -o wide
+                exit 1
+              fi
+              echo "OK: all BGPSessions cleaned up"

--- a/test/e2e/tests/bgp-route-policy/chainsaw-test.yaml
+++ b/test/e2e/tests/bgp-route-policy/chainsaw-test.yaml
@@ -1,0 +1,160 @@
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: bgp-route-policy
+spec:
+  description: >
+    Verify that BGPRoutePolicy resources are accepted by the API server with valid
+    conditions, and that the operator reconciles them without error. Requires
+    endpoints and a peering session to be established for the policy to have effect.
+  steps:
+    - name: setup-endpoints-and-peering
+      try:
+        - script:
+            env:
+              - name: KUBECONFIG
+                value: ($env.KUBECONFIG)
+            content: |
+              set -e
+              get_ipv6() {
+                kubectl get node "$1" \
+                  -o jsonpath='{range .status.addresses[?(@.type=="InternalIP")]}{.address}{"\n"}{end}' \
+                  | grep ':' | head -1
+              }
+              W1=$(get_ipv6 bgp-e2e-worker)
+              W2=$(get_ipv6 bgp-e2e-worker2)
+
+              kubectl apply -f - <<EOF
+              apiVersion: bgp.miloapis.com/v1alpha1
+              kind: BGPEndpoint
+              metadata:
+                name: node-bgp-e2e-worker-rp
+                labels:
+                  e2e-test: bgp-route-policy
+              spec:
+                address: "${W1}"
+                asNumber: 65000
+                addressFamilies:
+                  - afi: IPv6
+                    safi: Unicast
+              ---
+              apiVersion: bgp.miloapis.com/v1alpha1
+              kind: BGPEndpoint
+              metadata:
+                name: node-bgp-e2e-worker2-rp
+                labels:
+                  e2e-test: bgp-route-policy
+              spec:
+                address: "${W2}"
+                asNumber: 65000
+                addressFamilies:
+                  - afi: IPv6
+                    safi: Unicast
+              ---
+              apiVersion: bgp.miloapis.com/v1alpha1
+              kind: BGPPeeringPolicy
+              metadata:
+                name: e2e-rp-mesh
+              spec:
+                selector:
+                  matchLabels:
+                    e2e-test: bgp-route-policy
+                mode: mesh
+                sessionTemplate:
+                  holdTime: 30
+                  keepaliveTime: 10
+              EOF
+
+    - name: wait-for-session-established
+      try:
+        - script:
+            env:
+              - name: KUBECONFIG
+                value: ($env.KUBECONFIG)
+            content: |
+              set -e
+              ATTEMPTS=0
+              while [ "$ATTEMPTS" -lt 60 ]; do
+                STATE=$(kubectl get bgpsessions \
+                  -o jsonpath='{range .items[*]}{.status.sessionState}{"\n"}{end}' \
+                  | grep -c "^Established$" || true)
+                [ "$STATE" -ge 1 ] && break
+                ATTEMPTS=$((ATTEMPTS+1))
+                sleep 5
+              done
+              if [ "$STATE" -lt 1 ]; then
+                echo "ERROR: no BGP sessions reached Established"
+                kubectl get bgpsessions -o wide
+                exit 1
+              fi
+              echo "OK: BGP session Established"
+
+    - name: create-export-route-policy
+      try:
+        - apply:
+            resource:
+              apiVersion: bgp.miloapis.com/v1alpha1
+              kind: BGPRoutePolicy
+              metadata:
+                name: e2e-export-filter
+              spec:
+                type: Export
+                statements:
+                  - prefixSet:
+                      - cidr: "2001:db8::/32"
+                        maskLengthMin: 32
+                        maskLengthMax: 48
+                    action: Accept
+                  - action: Reject
+
+    - name: assert-route-policy-applied
+      try:
+        - assert:
+            resource:
+              apiVersion: bgp.miloapis.com/v1alpha1
+              kind: BGPRoutePolicy
+              metadata:
+                name: e2e-export-filter
+              # The resource should be accepted by the API server and have no
+              # error conditions set by the operator.
+              (metadata.name): e2e-export-filter
+
+    - name: assert-no-error-condition
+      try:
+        - script:
+            env:
+              - name: KUBECONFIG
+                value: ($env.KUBECONFIG)
+            content: |
+              set -e
+              # If the operator sets any error condition the test fails.
+              CONDITIONS=$(kubectl get bgproutepolicy e2e-export-filter \
+                -o jsonpath='{.status.conditions[*].type}' 2>/dev/null || echo "")
+              if echo "$CONDITIONS" | grep -qi "error\|failed\|invalid"; then
+                echo "ERROR: unexpected error condition on BGPRoutePolicy"
+                kubectl get bgproutepolicy e2e-export-filter -o yaml
+                exit 1
+              fi
+              echo "OK: no error conditions on BGPRoutePolicy"
+
+      finally:
+        - delete:
+            ref:
+              apiVersion: bgp.miloapis.com/v1alpha1
+              kind: BGPRoutePolicy
+              name: e2e-export-filter
+        - delete:
+            ref:
+              apiVersion: bgp.miloapis.com/v1alpha1
+              kind: BGPPeeringPolicy
+              name: e2e-rp-mesh
+        - delete:
+            ref:
+              apiVersion: bgp.miloapis.com/v1alpha1
+              kind: BGPEndpoint
+              name: node-bgp-e2e-worker-rp
+        - delete:
+            ref:
+              apiVersion: bgp.miloapis.com/v1alpha1
+              kind: BGPEndpoint
+              name: node-bgp-e2e-worker2-rp

--- a/test/e2e/tests/session-lifecycle/chainsaw-test.yaml
+++ b/test/e2e/tests/session-lifecycle/chainsaw-test.yaml
@@ -1,0 +1,155 @@
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: session-lifecycle
+spec:
+  description: >
+    Verify the lifecycle of a manually-created BGPSession: the session reaches
+    Established state and GoBGP removes the peer when the session is deleted.
+  steps:
+    - name: create-endpoints-and-manual-session
+      try:
+        - script:
+            env:
+              - name: KUBECONFIG
+                value: ($env.KUBECONFIG)
+            content: |
+              set -e
+              get_ipv6() {
+                kubectl get node "$1" \
+                  -o jsonpath='{range .status.addresses[?(@.type=="InternalIP")]}{.address}{"\n"}{end}' \
+                  | grep ':' | head -1
+              }
+              W2=$(get_ipv6 bgp-e2e-worker2)
+              W3=$(get_ipv6 bgp-e2e-worker3)
+
+              kubectl apply -f - <<EOF
+              apiVersion: bgp.miloapis.com/v1alpha1
+              kind: BGPEndpoint
+              metadata:
+                name: node-bgp-e2e-worker2-lc
+                labels:
+                  e2e-test: session-lifecycle
+              spec:
+                address: "${W2}"
+                asNumber: 65000
+                addressFamilies:
+                  - afi: IPv6
+                    safi: Unicast
+              ---
+              apiVersion: bgp.miloapis.com/v1alpha1
+              kind: BGPEndpoint
+              metadata:
+                name: node-bgp-e2e-worker3-lc
+                labels:
+                  e2e-test: session-lifecycle
+              spec:
+                address: "${W3}"
+                asNumber: 65000
+                addressFamilies:
+                  - afi: IPv6
+                    safi: Unicast
+              ---
+              apiVersion: bgp.miloapis.com/v1alpha1
+              kind: BGPSession
+              metadata:
+                name: e2e-manual-session-w2-w3
+              spec:
+                localEndpoint: node-bgp-e2e-worker2-lc
+                remoteEndpoint: node-bgp-e2e-worker3-lc
+                holdTime: 30
+                keepaliveTime: 10
+              EOF
+
+    - name: assert-session-configured
+      try:
+        # The Configured condition must be True before the session can reach Established.
+        - assert:
+            resource:
+              apiVersion: bgp.miloapis.com/v1alpha1
+              kind: BGPSession
+              metadata:
+                name: e2e-manual-session-w2-w3
+              status:
+                (conditions[?type=='Configured'].status | [0]): "True"
+
+    - name: assert-session-established
+      try:
+        - assert:
+            resource:
+              apiVersion: bgp.miloapis.com/v1alpha1
+              kind: BGPSession
+              metadata:
+                name: e2e-manual-session-w2-w3
+              status:
+                sessionState: Established
+
+    - name: verify-gobgp-peer-present
+      try:
+        - script:
+            env:
+              - name: KUBECONFIG
+                value: ($env.KUBECONFIG)
+            content: |
+              set -e
+              # Get the worker2 bgp pod (it owns the local endpoint)
+              W3=$(kubectl get node bgp-e2e-worker3 \
+                -o jsonpath='{range .status.addresses[?(@.type=="InternalIP")]}{.address}{"\n"}{end}' \
+                | grep ':' | head -1)
+              # Exec into the bgp pod on any node and verify the peer exists
+              POD=$(kubectl -n bgp-system get pod \
+                -l app.kubernetes.io/name=bgp \
+                -o jsonpath='{.items[0].metadata.name}')
+              echo "Checking GoBGP peer $W3 in pod $POD"
+              kubectl -n bgp-system exec "$POD" -c gobgpd -- \
+                gobgp neighbor | grep -q "${W3}"
+              echo "OK: peer $W3 present in GoBGP"
+
+    - name: delete-session-and-verify-peer-removed
+      try:
+        - delete:
+            ref:
+              apiVersion: bgp.miloapis.com/v1alpha1
+              kind: BGPSession
+              name: e2e-manual-session-w2-w3
+        - script:
+            env:
+              - name: KUBECONFIG
+                value: ($env.KUBECONFIG)
+            content: |
+              set -e
+              W3=$(kubectl get node bgp-e2e-worker3 \
+                -o jsonpath='{range .status.addresses[?(@.type=="InternalIP")]}{.address}{"\n"}{end}' \
+                | grep ':' | head -1)
+              POD=$(kubectl -n bgp-system get pod \
+                -l app.kubernetes.io/name=bgp \
+                -o jsonpath='{.items[0].metadata.name}')
+              echo "Verifying peer $W3 removed from GoBGP in pod $POD"
+
+              ATTEMPTS=0
+              STILL_PRESENT=1
+              while [ "$STILL_PRESENT" -eq 1 ] && [ "$ATTEMPTS" -lt 30 ]; do
+                OUTPUT=$(kubectl -n bgp-system exec "$POD" -c gobgpd -- \
+                  gobgp neighbor 2>/dev/null || true)
+                echo "$OUTPUT" | grep -q "${W3}" && STILL_PRESENT=1 || STILL_PRESENT=0
+                ATTEMPTS=$((ATTEMPTS+1))
+                [ "$STILL_PRESENT" -eq 1 ] && sleep 5
+              done
+
+              if [ "$STILL_PRESENT" -eq 1 ]; then
+                echo "ERROR: peer $W3 still present in GoBGP after session deletion"
+                exit 1
+              fi
+              echo "OK: peer $W3 removed from GoBGP"
+
+      finally:
+        - delete:
+            ref:
+              apiVersion: bgp.miloapis.com/v1alpha1
+              kind: BGPEndpoint
+              name: node-bgp-e2e-worker2-lc
+        - delete:
+            ref:
+              apiVersion: bgp.miloapis.com/v1alpha1
+              kind: BGPEndpoint
+              name: node-bgp-e2e-worker3-lc

--- a/test/e2e/tests/system-readiness/chainsaw-test.yaml
+++ b/test/e2e/tests/system-readiness/chainsaw-test.yaml
@@ -1,0 +1,99 @@
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: system-readiness
+spec:
+  description: Verify BGP system components are healthy before running functional tests
+  steps:
+    - name: bgp-daemonset-ready
+      try:
+        - assert:
+            resource:
+              apiVersion: apps/v1
+              kind: DaemonSet
+              metadata:
+                name: bgp
+                namespace: bgp-system
+              status:
+                (numberReady == desiredNumberScheduled): true
+
+    - name: bgp-pods-two-containers
+      try:
+        # Each pod runs bgp + gobgpd — verify at least one pod has both containers ready.
+        - script:
+            env:
+              - name: KUBECONFIG
+                value: ($env.KUBECONFIG)
+            content: |
+              set -e
+              READY=$(kubectl -n bgp-system get pods \
+                -l app.kubernetes.io/name=bgp \
+                -o jsonpath='{range .items[*]}{.status.containerStatuses[*].ready}{"\n"}{end}' \
+                | grep -c "true true" || true)
+              if [ "$READY" -eq 0 ]; then
+                echo "ERROR: no bgp pods found with both containers ready (bgp + gobgpd)"
+                exit 1
+              fi
+              echo "OK: $READY pod(s) with both containers ready"
+
+    - name: bgp-configuration-speaker-ready
+      try:
+        - assert:
+            resource:
+              apiVersion: bgp.miloapis.com/v1alpha1
+              kind: BGPConfiguration
+              metadata:
+                name: default
+              status:
+                (conditions[?type=='SpeakerReady'].status | [0]): "True"
+
+    - name: crds-established
+      try:
+        - assert:
+            resource:
+              apiVersion: apiextensions.k8s.io/v1
+              kind: CustomResourceDefinition
+              metadata:
+                name: bgpconfigurations.bgp.miloapis.com
+              status:
+                (conditions[?type=='Established'].status | [0]): "True"
+        - assert:
+            resource:
+              apiVersion: apiextensions.k8s.io/v1
+              kind: CustomResourceDefinition
+              metadata:
+                name: bgpsessions.bgp.miloapis.com
+              status:
+                (conditions[?type=='Established'].status | [0]): "True"
+        - assert:
+            resource:
+              apiVersion: apiextensions.k8s.io/v1
+              kind: CustomResourceDefinition
+              metadata:
+                name: bgpendpoints.bgp.miloapis.com
+              status:
+                (conditions[?type=='Established'].status | [0]): "True"
+        - assert:
+            resource:
+              apiVersion: apiextensions.k8s.io/v1
+              kind: CustomResourceDefinition
+              metadata:
+                name: bgppeeringpolicies.bgp.miloapis.com
+              status:
+                (conditions[?type=='Established'].status | [0]): "True"
+        - assert:
+            resource:
+              apiVersion: apiextensions.k8s.io/v1
+              kind: CustomResourceDefinition
+              metadata:
+                name: bgpadvertisements.bgp.miloapis.com
+              status:
+                (conditions[?type=='Established'].status | [0]): "True"
+        - assert:
+            resource:
+              apiVersion: apiextensions.k8s.io/v1
+              kind: CustomResourceDefinition
+              metadata:
+                name: bgproutepolicies.bgp.miloapis.com
+              status:
+                (conditions[?type=='Established'].status | [0]): "True"


### PR DESCRIPTION
## Summary

- Adds a `test/e2e/` directory with a complete end-to-end test environment for the BGP control plane operator
- Five chainsaw test suites covering system readiness, BGP peering, prefix advertisement, route policy, and session lifecycle
- Taskfile-driven cluster management using kind + Cilium CNI + kustomize overlay

## What's Included

### Infrastructure
- `test/e2e/kind-config.yaml` — dual-stack kind cluster (1 control-plane, 3 workers with region labels, no default CNI)
- `test/e2e/Taskfile.yml` — full lifecycle task runner with tasks: `cluster-create`, `images-build`, `images-build-gobgpd`, `images-load`, `deploy`, `test`, `cluster-delete`, and `default` (full suite)
- `test/e2e/overlay/kustomization.yaml` — kustomize overlay that sets `e2e-local` image tags and patches `LOCAL_ENDPOINT` to `node-$(NODE_NAME)` for each DaemonSet pod
- `test/e2e/fixtures/bgpconfiguration-default.yaml` — default BGPConfiguration (AS 65000, port 1790, IPv6 unicast)
- `test/e2e/chainsaw-config.yaml` — chainsaw runner with 5m assert timeout

### Chainsaw Test Suites

| Suite | What it tests |
|-------|---------------|
| `system-readiness` | DaemonSet ready, both containers (bgp+gobgpd) running, `SpeakerReady=True` on BGPConfiguration, all 6 CRDs Established |
| `bgp-peering` | Resolves node IPv6 addresses, creates 3 BGPEndpoints, applies mesh BGPPeeringPolicy, asserts 3 sessions created and all Established, verifies cleanup on delete |
| `bgp-advertisement` | Creates BGPAdvertisement with test prefix `2001:db8:e2e::/48`, verifies `advertisedPrefixCount >= 1`, confirms prefix in GoBGP RIB via `gobgp global rib` exec, verifies withdrawal on deletion |
| `bgp-route-policy` | Creates export BGPRoutePolicy with prefix filter, verifies no error conditions set by operator |
| `session-lifecycle` | Creates BGPEndpoints + manual BGPSession, asserts `Configured=True` then `Established`, verifies GoBGP peer present, deletes session, verifies GoBGP peer removed |

### Makefile
- `make test-e2e` — runs `task default` in `test/e2e/`
- `make chainsaw` — installs chainsaw v0.2.12 into `./bin/`

## Test plan

- [ ] `cd test/e2e && task cluster-create` — kind cluster comes up with 4 nodes
- [ ] `task images-build` — both `bgp:e2e-local` and `gobgpd:e2e-local` images build
- [ ] `task deploy` — Cilium ready, CRDs Established, BGP pods 2/2 Ready
- [ ] `task test` — all 5 chainsaw suites pass
- [ ] `task cluster-delete` — cluster torn down cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)