### PR TITLE
chore: move and optimize renovate config

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,107 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:recommended",
+    ":dependencyDashboard",
+    ":semanticCommits"
+  ],
+  "schedule": ["before 6am on Monday"],
+  "timezone": "America/New_York",
+  "labels": ["dependencies"],
+  "minimumReleaseAge": "3 days",
+  "packageRules": [
+    {
+      "description": "Disable Go version upgrades in go.mod (go directive and toolchain directive)",
+      "matchManagers": ["gomod"],
+      "matchDepNames": ["go"],
+      "enabled": false
+    },
+    {
+      "description": "Disable golang Docker image version upgrades",
+      "matchManagers": ["dockerfile"],
+      "matchDepNames": ["golang"],
+      "enabled": false
+    },
+    {
+      "description": "Disable go-version upgrades in GitHub Actions (actions/setup-go)",
+      "matchManagers": ["github-actions"],
+      "matchDepNames": ["go"],
+      "enabled": false
+    },
+    {
+      "description": "Disable vishvananda/netlink updates — pinned to a pseudo-version commit",
+      "matchPackageNames": ["github.com/vishvananda/netlink"],
+      "enabled": false
+    },
+    {
+      "description": "Group all Go dependencies (excluding k8s core, which has its own cadence)",
+      "matchManagers": ["gomod"],
+      "excludePackageNames": [
+        "sigs.k8s.io/controller-runtime",
+        "k8s.io/client-go",
+        "k8s.io/api",
+        "k8s.io/apimachinery",
+        "k8s.io/apiextensions-apiserver"
+      ],
+      "groupName": "Go dependencies",
+      "groupSlug": "go-deps"
+    },
+    {
+      "description": "k8s core — grouped, slower cadence",
+      "matchManagers": ["gomod"],
+      "matchPackageNames": [
+        "sigs.k8s.io/controller-runtime",
+        "k8s.io/client-go",
+        "k8s.io/api",
+        "k8s.io/apimachinery",
+        "k8s.io/apiextensions-apiserver"
+      ],
+      "groupName": "k8s core libraries",
+      "groupSlug": "k8s-core",
+      "schedule": ["before 6am on the first day of the month"]
+    },
+    {
+      "description": "Group all GitHub Actions version bumps",
+      "matchManagers": ["github-actions"],
+      "groupName": "GitHub Actions",
+      "groupSlug": "gha"
+    },
+    {
+      "description": "Group all Dockerfile base image updates",
+      "matchManagers": ["dockerfile"],
+      "groupName": "Docker base images",
+      "groupSlug": "docker-images"
+    },
+    {
+      "description": "Automerge patch/minor for non-k8s Go deps",
+      "matchManagers": ["gomod"],
+      "matchUpdateTypes": ["patch", "minor"],
+      "excludePackageNames": [
+        "sigs.k8s.io/controller-runtime",
+        "k8s.io/client-go",
+        "k8s.io/api",
+        "k8s.io/apimachinery",
+        "k8s.io/apiextensions-apiserver"
+      ],
+      "automerge": true,
+      "automergeType": "pr",
+      "platformAutomerge": true
+    },
+    {
+      "description": "Never automerge majors",
+      "matchUpdateTypes": ["major"],
+      "automerge": false,
+      "labels": ["dependencies", "major-update"]
+    }
+  ],
+  "vulnerabilityAlerts": {
+    "enabled": true,
+    "labels": ["security"],
+    "schedule": ["at any time"]
+  },
+  "constraints": {
+    "go": "1.24"
+  },
+  "prConcurrentLimit": 5,
+  "prHourlyLimit": 2
+}


### PR DESCRIPTION
## Summary

- Moves `renovate.json` to `.github/renovate.json` (standard Renovate location)
- Fixes several issues that were causing or could cause extra PRs per dependency change

## Changes

| Change | Reason |
|---|---|
| `config:base` → `config:recommended` | Superseded preset with better defaults |
| `"EST"` → `"America/New_York"` | Fixed UTC offset — `EST` doesn't observe DST, schedule drifted 1h in summer |
| Added `minimumReleaseAge: "3 days"` | Avoids PRs for packages yanked or hot-fixed shortly after release |
| Fixed GHA Go version suppression | `matchPackageNames: ["actions/go-versions"]` was wrong — Renovate tracks this as `depName: go`; rule was silently doing nothing |
| Added `vishvananda/netlink` disable rule | Pinned to a pseudo-version commit; Renovate would attempt to "update" it to a tagged release |
| Explicit `excludePackageNames` on Go deps group | k8s packages previously relied on implicit rule-ordering to land in the `k8s-core` group; now explicit |
| Added `matchManagers: ["gomod"]` to k8s-core rule | Scopes the rule explicitly to gomod |
| Added Docker base images group | `alpine:3.19` in `build/Dockerfile` was ungrouped — every alpine release created its own PR |

## Net PR topology after this change

- **Weekly (Monday):** 1 PR for non-k8s Go deps (auto-merged if patch/minor), 1 PR for GHA actions, 1 PR for Docker base images
- **Monthly (1st):** 1 PR for k8s core libraries
- **Any time:** security vulnerability PRs only

🤖 Generated with [Claude Code](https://claude.com/claude-code)