### PR TITLE
Add CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @datum-cloud/engineering


### PR DESCRIPTION
## Summary

- Adds `.github/CODEOWNERS` file assigning `@datum-cloud/engineering` as the default code owner for all files in the repository

## Test plan

- [ ] Verify that PRs trigger a review request to `@datum-cloud/engineering`

🤖 Generated with [Claude Code](https://claude.com/claude-code)