### PR TITLE
add Claude Code project settings

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,31 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(git commit:*)",
+      "Bash(git mv:*)",
+      "Bash(git checkout:*)",
+      "Bash(git add:*)",
+      "Bash(tree:*)",
+      "Bash(find:*)",
+      "Bash(grep:*)",
+      "Bash(go build:*)",
+      "Bash(go mod tidy:*)",
+      "Bash(go list:*)",
+      "Bash(go vet:*)",
+      "Bash(gofmt:*)",
+      "WebSearch"
+    ]
+  },
+  "extraKnownMarketplaces": {
+    "datum-claude-code-plugins": {
+      "source": {
+        "source": "github",
+        "repo": "datum-cloud/claude-code-plugins"
+      }
+    }
+  },
+  "enabledPlugins": {
+    "datum-platform@datum-claude-code-plugins": true,
+    "datum-gtm@datum-claude-code-plugins": true
+  }
+}


### PR DESCRIPTION
## Summary

- Adds `.claude/settings.json` with project-level permissions for common development commands (git, find, grep, go toolchain)
- Configures the `datum-platform` and `datum-gtm` Claude Code plugins from the `datum-cloud/claude-code-plugins` marketplace

## Test plan

- [ ] Verify Claude Code picks up the settings when opened in the repo root
- [ ] Confirm plugin-provided skills are available in the session

🤖 Generated with [Claude Code](https://claude.com/claude-code)