### PR TITLE
docs: rewrite README and expand Taskfile

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,32 +1,49 @@
-# BGP Control Plane
+# Cosmos
 
-Manage [BGP][bgp] topology declaratively through Kubernetes
-[Custom Resource Definitions][crds] (CRDs), powered by
-[GoBGP][gobgp].
+[![CI](https://github.com/milo-os/cosmos/actions/workflows/ci.yaml/badge.svg)](https://github.com/milo-os/cosmos/actions/workflows/ci.yaml)
 
-You define BGP speakers, sessions, and policies as Kubernetes resources. The
-controller reconciles them into a running GoBGP instance on each node and
-programs learned routes into the kernel.
+Cosmos is a BGP control plane for Kubernetes. You define speakers, sessions,
+policies, and VPCs as Kubernetes resources; the controller reconciles them into
+a running [GoBGP][gobgp] instance on each node and programs learned routes into
+the kernel.
 
-**API group:** `bgp.miloapis.com` | **Version:** `v1alpha1`
+**API groups:** `bgp.miloapis.com/v1alpha1` · `vpc.miloapis.com/v1alpha1`
+
+---
+
+## How it works
+
+Cosmos runs as a DaemonSet. Each pod has two runtime containers:
+
+- **`bgp`** — the controller; watches CRDs and configures GoBGP over [gRPC][grpc]
+- **`gobgpd`** — the GoBGP daemon; handles the BGP wire protocol
+
+An init container discovers the node's global IPv6 address and writes the
+initial GoBGP configuration before the main containers start. The controller
+programs kernel routes from BGP [RIB][rib] events via [netlink][netlink].
+
+The controller has no built-in knowledge of nodes, clusters, or datacenter
+layout — all topology is expressed through CRDs.
 
 ---
 
 ## Key features
 
-- **Topology-agnostic.** The controller has no built-in knowledge of nodes,
-  clusters, or datacenter layout. All topology lives in the CRDs you create.
-- **CNI-independent.** Works with any [CNI][cni] — or no CNI at all. No
-  dependency on Cilium, Calico, or any other network plugin.
-- **Declarative session management.** `BGPPeeringPolicy` automates session
-  creation through [label selectors][label-selectors]. Full-mesh and
-  [route-reflector][rr] topologies are both supported.
-- **Producer/consumer model.** Any system — node operators, cluster discovery,
-  automation pipelines, or humans — can create BGP CRDs. The controller
-  reconciles them uniformly.
-- **[GoBGP][gobgp] sidecar.** Each node runs its own GoBGP daemon. The
-  controller configures it over [gRPC][grpc] and programs kernel routes from
-  BGP [RIB][rib] events.
+- **Topology-agnostic.** No built-in node or cluster model; topology lives entirely in CRDs.
+- **CNI-independent.** Works with any [CNI][cni] or none at all.
+- **Declarative session management.** `BGPPeeringPolicy` creates sessions through label selectors; full-mesh and [route-reflector][rr] topologies both supported.
+- **Producer/consumer model.** Any system — node operators, automation pipelines, humans — can create BGP CRDs; the controller reconciles them uniformly.
+- **VPC primitives.** `VPC` and `VPCAttachment` CRDs model virtual networks and their interface bindings.
+
+---
+
+## Prerequisites
+
+- Kubernetes cluster with IPv6 enabled (nodes need global-scope IPv6 addresses)
+- `kubectl` configured for your cluster
+- Container images accessible to your cluster:
+  - `ghcr.io/milo-os/cosmos:latest` — controller + init container
+  - A GoBGP daemon image (`gobgpd:latest` by default)
 
 ---
 
@@ -35,6 +52,7 @@ programs learned routes into the kernel.
 Install the CRDs and deploy the controller:
 
 ```bash
+kubectl apply -k config/crd
 kubectl apply -k config/deploy
 ```
 
@@ -51,7 +69,8 @@ spec:
   routerIDSource: NodeIP
 ```
 
-Create `BGPEndpoint` resources for your nodes and a peering policy:
+Create `BGPEndpoint` resources for your nodes and wire them together with a
+peering policy:
 
 ```yaml
 apiVersion: bgp.miloapis.com/v1alpha1
@@ -81,31 +100,66 @@ Check session state:
 kubectl get bgpsess
 ```
 
-For a complete walkthrough, see the
-[Getting Started guide](docs/getting-started.md).
+For a complete walkthrough, see the [Getting Started guide](docs/getting-started.md).
 
 ---
 
-## CRDs
+## API reference
 
-| Resource | Short name | Scope | Description |
-|----------|-----------|-------|-------------|
-| `BGPConfiguration` | `bgpconfig` | Cluster | Speaker identity: [AS number][asn], listen port, router ID. One per cluster. |
-| `BGPEndpoint` | `bgpep` | Cluster | BGP speaker address and AS number. One per node (or manually created). |
-| `BGPSession` | `bgpsess` | Cluster | Peering relationship between two endpoints. |
-| `BGPPeeringPolicy` | `bgppp` | Cluster | Automates session creation through label selectors. |
-| `BGPAdvertisement` | `bgpadvert` | Cluster | Prefix advertisement with optional [communities][bgp-communities] and [LOCAL_PREF][local-pref]. |
-| `BGPRoutePolicy` | `bgprp` | Cluster | Import/export filtering with prefix matching. |
+### BGP — `bgp.miloapis.com/v1alpha1`
+
+| Resource           | Short name   | Description                                                          |
+|--------------------|--------------|----------------------------------------------------------------------|
+| `BGPConfiguration` | `bgpconfig`  | Speaker identity: AS number, listen port, router ID. One per cluster.|
+| `BGPEndpoint`      | `bgpep`      | BGP speaker address and AS number. One per node.                     |
+| `BGPSession`       | `bgpsess`    | Peering relationship between two endpoints.                          |
+| `BGPPeeringPolicy` | `bgppp`      | Automates session creation via label selectors.                      |
+| `BGPAdvertisement` | `bgpadvert`  | Prefix advertisement with optional communities and LOCAL_PREF.       |
+| `BGPRoutePolicy`   | `bgprp`      | Import/export filtering with prefix matching.                        |
+
+### VPC — `vpc.miloapis.com/v1alpha1`
+
+| Resource        | Description                                                   |
+|-----------------|---------------------------------------------------------------|
+| `VPC`           | Virtual network with one or more CIDR prefixes.               |
+| `VPCAttachment` | Binds a VPC to a named interface with assigned addresses.     |
+
+---
+
+## Development
+
+Install development tools first:
+
+```bash
+task tools
+```
+
+| Command           | Description                                                          |
+|-------------------|----------------------------------------------------------------------|
+| `task build`      | Compile all packages                                                 |
+| `task test`       | Run unit tests                                                       |
+| `task lint`       | Run golangci-lint                                                    |
+| `task vet`        | Run go vet                                                           |
+| `task generate`   | Regenerate deepcopy methods                                          |
+| `task manifests`  | Regenerate CRD manifests from API types                              |
+| `task test-e2e`   | Create a kind cluster, deploy, run the full E2E suite, and tear down |
+
+E2E tests use [Chainsaw][chainsaw] and run against a [kind][kind] cluster. The
+full suite also runs in CI on every pull request.
+
+Build the container image:
+
+```bash
+docker build -f build/Dockerfile -t ghcr.io/milo-os/cosmos:dev .
+```
 
 ---
 
 ## Documentation
 
-- [Service design](docs/design/) — motivation, architecture, controller
-  internals, and design decisions
-- [API reference](docs/api/) — complete field documentation for all six CRDs
-- [Getting started](docs/getting-started.md) — deploy the control plane and
-  establish your first BGP session
+- [Getting started](docs/getting-started.md) — deploy and establish your first BGP session
+- [Service design](docs/design/) — architecture, controller internals, and design decisions
+- [Enhancements](docs/enhancements/) — accepted design proposals
 
 ### Examples
 
@@ -117,25 +171,17 @@ For a complete walkthrough, see the
 
 ---
 
-## Building
+## License
 
-```bash
-# Build the controller binary
-CGO_ENABLED=0 go build -o bgp ./cmd/bgp
-
-# Build the container image
-docker build -f build/Dockerfile -t ghcr.io/milo-os/bgp:latest .
-```
+[Apache 2.0](LICENSE)
 
 <!-- References -->
 [bgp]: https://datatracker.ietf.org/doc/html/rfc4271
 [gobgp]: https://github.com/osrg/gobgp
-[crds]: https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/
-[cni]: https://www.cni.dev/
-[label-selectors]: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
-[rr]: https://datatracker.ietf.org/doc/html/rfc4456
 [grpc]: https://grpc.io/
 [rib]: https://en.wikipedia.org/wiki/Routing_table
-[asn]: https://www.iana.org/assignments/as-numbers/as-numbers.xhtml
-[bgp-communities]: https://datatracker.ietf.org/doc/html/rfc1997
-[local-pref]: https://datatracker.ietf.org/doc/html/rfc4271#section-5.1.5
+[netlink]: https://man7.org/linux/man-pages/man7/netlink.7.html
+[cni]: https://www.cni.dev/
+[rr]: https://datatracker.ietf.org/doc/html/rfc4456
+[chainsaw]: https://kyverno.github.io/chainsaw/
+[kind]: https://kind.sigs.k8s.io/

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -1,41 +1,88 @@
 version: '3'
 
 vars:
-  GOBIN: "{{.ROOT_DIR}}/bin"
-  CHAINSAW_VERSION: v0.2.12
-  CONTROLLER_GEN_VERSION: v0.18.0
+  LOCALBIN:
+    sh: echo "$(pwd)/bin"
+  GOBIN:
+    sh: |
+      gobin=$(go env GOBIN)
+      [ -n "$gobin" ] && echo "$gobin" || echo "$(go env GOPATH)/bin"
+  GOLANGCI_LINT: '{{.LOCALBIN}}/golangci-lint'
+  CONTROLLER_GEN: '{{.LOCALBIN}}/controller-gen'
+  CHAINSAW: '{{.LOCALBIN}}/chainsaw'
   GOLANGCI_LINT_VERSION: v2.1.6
+  CONTROLLER_GEN_VERSION: v0.18.0
+  CHAINSAW_VERSION: v0.2.12
 
 tasks:
-  build:
-    desc: Build all packages
+  default:
+    silent: true
     cmds:
-      - go build ./...
+      - task --list
+
+  ##
+  ## Development
+  ##
+
+  fmt:
+    desc: Run go fmt against code
+    run: once
+    cmds:
+      - go fmt ./...
+
+  vet:
+    desc: Run go vet against code
+    run: once
+    cmds:
+      - GOOS=linux go vet ./...
 
   test:
     desc: Run unit tests
+    deps: [fmt, vet]
     cmds:
-      - go test ./...
+      - GOOS=linux go test $(go list ./... | grep -v /e2e) -coverprofile cover.out
 
   lint:
-    desc: Run golangci-lint
+    desc: Run golangci-lint linter
+    deps: [golangci-lint]
     cmds:
-      - golangci-lint run ./...
+      - '{{.GOLANGCI_LINT}} run'
 
-  vet:
-    desc: Run go vet
+  lint-fix:
+    desc: Run golangci-lint linter and perform fixes
+    deps: [golangci-lint]
     cmds:
-      - go vet ./...
+      - '{{.GOLANGCI_LINT}} run --fix'
+
+  ##
+  ## Build
+  ##
+
+  build:
+    desc: Build all packages
+    deps: [fmt, vet]
+    cmds:
+      - go build ./...
+
+  ##
+  ## Code generation
+  ##
 
   generate:
     desc: Generate deepcopy methods
+    deps: [controller-gen]
     cmds:
-      - controller-gen object:headerFile="hack/boilerplate.go.txt" paths="./..."
+      - '{{.CONTROLLER_GEN}} object:headerFile="hack/boilerplate.go.txt" paths="./..."'
 
   manifests:
     desc: Generate CRD manifests
+    deps: [controller-gen]
     cmds:
-      - controller-gen crd paths="./api/..." output:crd:artifacts:config=config/crd
+      - '{{.CONTROLLER_GEN}} crd paths="./api/..." output:crd:artifacts:config=config/crd'
+
+  ##
+  ## Testing
+  ##
 
   test-e2e:
     desc: Run the full E2E suite (create cluster, deploy, test, teardown)
@@ -43,13 +90,63 @@ tasks:
     cmds:
       - task default
 
-  chainsaw:
-    desc: Install chainsaw test runner
+  ##
+  ## Cleanup
+  ##
+
+  clean:
+    desc: Remove build artifacts and temporary files
     cmds:
-      - GOBIN={{.GOBIN}} go install github.com/kyverno/chainsaw@{{.CHAINSAW_VERSION}}
+      - rm -rf bin/
+      - rm -f cover.out
+
+  ##
+  ## Dependencies
+  ##
+
+  golangci-lint:
+    desc: Download golangci-lint locally if necessary
+    run: once
+    cmds:
+      - task: install-tool
+        vars:
+          TARGET: '{{.GOLANGCI_LINT}}'
+          PACKAGE: github.com/golangci/golangci-lint/v2/cmd/golangci-lint
+          VERSION: '{{.GOLANGCI_LINT_VERSION}}'
+
+  controller-gen:
+    desc: Download controller-gen locally if necessary
+    run: once
+    cmds:
+      - task: install-tool
+        vars:
+          TARGET: '{{.CONTROLLER_GEN}}'
+          PACKAGE: sigs.k8s.io/controller-tools/cmd/controller-gen
+          VERSION: '{{.CONTROLLER_GEN_VERSION}}'
+
+  chainsaw:
+    desc: Download chainsaw locally if necessary
+    run: once
+    cmds:
+      - task: install-tool
+        vars:
+          TARGET: '{{.CHAINSAW}}'
+          PACKAGE: github.com/kyverno/chainsaw
+          VERSION: '{{.CHAINSAW_VERSION}}'
 
   tools:
     desc: Install all development tools
+    deps: [golangci-lint, controller-gen, chainsaw]
+
+  install-tool:
+    internal: true
     cmds:
-      - GOBIN={{.GOBIN}} go install github.com/kyverno/chainsaw@{{.CHAINSAW_VERSION}}
-      - GOBIN={{.GOBIN}} go install sigs.k8s.io/controller-tools/cmd/controller-gen@{{.CONTROLLER_GEN_VERSION}}
+      - mkdir -p {{.LOCALBIN}}
+      - |
+        if [ ! -f "{{.TARGET}}-{{.VERSION}}" ]; then
+          echo "Downloading {{.PACKAGE}}@{{.VERSION}}"
+          rm -f "{{.TARGET}}" || true
+          GOBIN={{.LOCALBIN}} go install {{.PACKAGE}}@{{.VERSION}}
+          mv "{{.TARGET}}" "{{.TARGET}}-{{.VERSION}}"
+        fi
+        ln -sf "{{.TARGET}}-{{.VERSION}}" "{{.TARGET}}"


### PR DESCRIPTION
## Summary

- Rewrites the README: renames the project to Cosmos, adds a CI badge, architecture overview, prerequisites section, and surfaces the `vpc.miloapis.com` API group that was missing entirely
- Fixes the container image name (`ghcr.io/milo-os/bgp` → `ghcr.io/milo-os/cosmos`) and the quick-start CRD install step
- Aligns all Markdown table columns for readability
- Expands the Taskfile with `fmt`, `lint-fix`, `clean`, and per-tool versioned install targets under `bin/` to avoid redundant downloads on re-runs

## Test plan

- [ ] Verify CI badge resolves correctly after merge
- [ ] Run `task tools` and confirm binaries land under `bin/` with version suffixes
- [ ] Run `task build`, `task test`, `task lint` to confirm no regressions from Taskfile changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)