### PR TITLE
refactor: remove GoBGP sidecar — cosmos connects to external daemons

### DIFF
--- a/cmd/bgp/main.go
+++ b/cmd/bgp/main.go
@@ -52,10 +52,11 @@ func newRootCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "bgp",
 		Short: "BGP operator — reconciles BGP CRDs against local BGP daemons",
-		Long: `The BGP operator runs as a DaemonSet alongside FRR and/or GoBGP sidecar containers.
+		Long: `The BGP operator reconciles BGP CRDs against independently-running BGP daemons.
 It reads its cluster role from the cosmos-config ConfigMap in cosmos-system and
 reconciles BGPProvider, BGPInstance, BGPPeer, BGPAdvertisement, BGPRoutePolicy,
-BGPSession, and BGPExternalPeer CRDs.`,
+BGPSession, and BGPExternalPeer CRDs. BGPProvider resources specify the gRPC
+endpoint of a pre-existing daemon (FRR or GoBGP) that cosmos connects to.`,
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return run(cmd.Context(), opts)

--- a/config/deploy/daemonset.yaml
+++ b/config/deploy/daemonset.yaml
@@ -21,26 +21,6 @@ spec:
                   - key: node-role.kubernetes.io/control-plane
                     operator: DoesNotExist
       hostNetwork: true
-      initContainers:
-        - name: config-gen
-          image: busybox:1.36
-          command:
-            - /bin/sh
-            - -c
-            - |
-              NODE_IP=$(ip -6 addr show scope global | awk '/inet6/{print $2}' | cut -d/ -f1 | head -1)
-              if [ -z "$NODE_IP" ]; then
-                echo "ERROR: no global-scope IPv6 address found"
-                exit 1
-              fi
-              echo "Generating gobgp.conf with router-id=$NODE_IP"
-              sed "s/NODE_IP_PLACEHOLDER/$NODE_IP/g" /config-template/gobgp.conf > /config/gobgp.conf
-              cat /config/gobgp.conf
-          volumeMounts:
-            - name: config-template
-              mountPath: /config-template
-            - name: config
-              mountPath: /config
       containers:
         - name: bgp
           image: ghcr.io/milo-os/bgp:latest
@@ -76,25 +56,5 @@ spec:
               port: 8087
             initialDelaySeconds: 5
             periodSeconds: 10
-        - name: gobgpd
-          image: gobgpd:latest
-          imagePullPolicy: IfNotPresent
-          args: ["-f", "/config/gobgp.conf", "--log-level=debug", "-p"]
-          ports:
-            - containerPort: 1790
-              protocol: TCP
-              name: bgp
-            - containerPort: 50051
-              protocol: TCP
-              name: grpc
-          volumeMounts:
-            - name: config
-              mountPath: /config
-      volumes:
-        - name: config-template
-          configMap:
-            name: gobgp-config
-        - name: config
-          emptyDir: {}
       tolerations:
         - operator: Exists

--- a/config/deploy/kustomization.yaml
+++ b/config/deploy/kustomization.yaml
@@ -6,6 +6,5 @@ resources:
   - namespace.yaml
   - serviceaccount.yaml
   - clusterrole.yaml
-  - gobgp-config.yaml
   - daemonset.yaml
   - ../crd

--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -45,7 +45,7 @@ type Manager struct {
 	// implementations here. ProviderReconciler populates it at runtime.
 	Registry *provider.Registry
 	// NodeName is the Kubernetes node name for this pod. Used by ProviderReconciler
-	// to bootstrap local BGPProvider resources.
+	// to scope reconciliation to BGPProvider resources on this node.
 	NodeName    string
 	MetricsAddr string
 	HealthAddr  string
@@ -67,10 +67,6 @@ func (m *Manager) SetupWithManager(mgr ctrl.Manager) error {
 		if err := providerReconciler.SetupWithManager(mgr); err != nil {
 			return fmt.Errorf("setup ProviderReconciler: %w", err)
 		}
-
-		// Bootstrap local providers as a startup hook. The manager has not started
-		// yet so we schedule this via a Runnable that runs on Start.
-		mgr.Add(&bootstrapRunnable{reconciler: providerReconciler})
 	}
 
 	// InstanceReconciler: active in pop and infra.
@@ -191,16 +187,3 @@ func Run(ctx context.Context, metricsAddr, healthAddr, clusterRole, nodeName str
 	return mgr.Start(ctx)
 }
 
-// bootstrapRunnable is a ctrl.Runnable that bootstraps local BGPProvider resources
-// once the manager cache is synced.
-type bootstrapRunnable struct {
-	reconciler *ProviderReconciler
-}
-
-func (b *bootstrapRunnable) Start(ctx context.Context) error {
-	if err := b.reconciler.bootstrapLocalProviders(ctx); err != nil {
-		log.Printf("bgp/controller: bootstrap local providers: %v", err)
-	}
-	// Return nil — bootstrap failure is non-fatal; the normal reconcile loop will retry.
-	return nil
-}

--- a/internal/controller/provider_reconciler.go
+++ b/internal/controller/provider_reconciler.go
@@ -8,12 +8,10 @@ import (
 	"net"
 	"time"
 
-	corev1 "k8s.io/api/core/v1"
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -37,8 +35,6 @@ const (
 	LabelDaemon = "bgp.miloapis.com/daemon"
 	// LabelNode records the Kubernetes node name a provider runs on.
 	LabelNode = "bgp.miloapis.com/node"
-	// LabelManagedByBootstrap indicates the resource was created at controller bootstrap.
-	LabelManagedByBootstrap = "cosmos-bootstrap"
 	// LabelManagedByManagement indicates the resource was created by the management cluster controller.
 	LabelManagedByManagement = "cosmos-management"
 
@@ -97,12 +93,6 @@ func (r *ProviderReconciler) Reconcile(ctx context.Context, req reconcile.Reques
 	if err != nil {
 		return r.setProviderCondition(ctx, &bgpProvider, "Ready", metav1.ConditionFalse, "InvalidEndpoint",
 			fmt.Sprintf("spec has no endpoint configured: %v", err))
-	}
-
-	// v1alpha1 restriction: only loopback endpoints allowed.
-	if !isLoopback(endpoint) {
-		return r.setProviderCondition(ctx, &bgpProvider, "Ready", metav1.ConditionFalse, "RemoteProviderNotSupported",
-			fmt.Sprintf("endpoint %q is not a loopback address; remote providers are not supported in v1alpha1", endpoint))
 	}
 
 	// Validate endpoint is well-formed (host:port).
@@ -243,7 +233,7 @@ func (r *ProviderReconciler) setProviderCondition(
 		log.Printf("bgp/provider: patch status: %v", err)
 	}
 	// Hard validation errors do not requeue — the spec must be fixed.
-	if reason == "InvalidEndpoint" || reason == "RemoteProviderNotSupported" {
+	if reason == "InvalidEndpoint" {
 		return ctrl.Result{}, nil
 	}
 	return ctrl.Result{RequeueAfter: providerHealthRequeue}, nil
@@ -261,76 +251,6 @@ func (r *ProviderReconciler) newProviderImpl(bgpProvider *providersv1alpha1.BGPP
 	}
 }
 
-// bootstrapLocalProviders creates BGPProvider resources for FRR and GoBGP on the
-// local node if they do not exist. Called once at controller startup by the Manager.
-func (r *ProviderReconciler) bootstrapLocalProviders(ctx context.Context) error {
-	if r.NodeName == "" {
-		log.Printf("bgp/provider: NODE_NAME not set — skipping bootstrap")
-		return nil
-	}
-
-	// Fetch the Kubernetes Node to copy its labels.
-	var node corev1.Node
-	if err := r.Get(ctx, types.NamespacedName{Name: r.NodeName}, &node); err != nil {
-		return fmt.Errorf("get node %s: %w", r.NodeName, err)
-	}
-
-	daemons := []struct {
-		suffix   string
-		specType string
-		endpoint string
-	}{
-		{"frr", "FRR", "localhost:50051"},
-		{"gobgp", "GoBGP", "localhost:50051"},
-	}
-
-	for _, d := range daemons {
-		name := r.NodeName + "-" + d.suffix
-		var existing providersv1alpha1.BGPProvider
-		if err := r.Get(ctx, types.NamespacedName{Name: name}, &existing); err == nil {
-			continue // already exists
-		}
-
-		labels := make(map[string]string)
-		for k, v := range node.Labels {
-			labels[k] = v
-		}
-		labels[LabelManagedBy] = LabelManagedByBootstrap
-		labels[LabelDaemon] = d.specType
-		labels[LabelNode] = r.NodeName
-
-		bp := &providersv1alpha1.BGPProvider{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:   name,
-				Labels: labels,
-				Annotations: map[string]string{
-					LabelNode: r.NodeName,
-				},
-			},
-			Spec: buildProviderSpec(d.specType, d.endpoint),
-		}
-
-		if err := r.Create(ctx, bp); err != nil {
-			log.Printf("bgp/provider: bootstrap %s: %v", name, err)
-		} else {
-			log.Printf("bgp/provider: bootstrapped %s (type=%s endpoint=%s)", name, d.specType, d.endpoint)
-		}
-	}
-	return nil
-}
-
-// buildProviderSpec constructs a BGPProviderSpec for the given daemon type.
-func buildProviderSpec(daemonType, endpoint string) providersv1alpha1.BGPProviderSpec {
-	spec := providersv1alpha1.BGPProviderSpec{Type: daemonType}
-	switch daemonType {
-	case "FRR":
-		spec.FRR = &providersv1alpha1.FRRProviderConfig{Endpoint: endpoint}
-	case "GoBGP":
-		spec.GoBGP = &providersv1alpha1.GoBGPProviderConfig{Endpoint: endpoint}
-	}
-	return spec
-}
-
 // endpointFromSpec extracts the configured endpoint from a BGPProvider spec.
 func endpointFromSpec(bgpProvider *providersv1alpha1.BGPProvider) (string, error) {
 	switch bgpProvider.Spec.Type {
@@ -344,20 +264,6 @@ func endpointFromSpec(bgpProvider *providersv1alpha1.BGPProvider) (string, error
 		}
 	}
 	return "", fmt.Errorf("no endpoint configured for type %q", bgpProvider.Spec.Type)
-}
-
-// isLoopback returns true when endpoint is a loopback address or "localhost".
-func isLoopback(endpoint string) bool {
-	host, _, err := net.SplitHostPort(endpoint)
-	if err != nil {
-		// Try treating the whole string as a host.
-		host = endpoint
-	}
-	ip := net.ParseIP(host)
-	if ip == nil {
-		return host == "localhost"
-	}
-	return ip.IsLoopback()
 }
 
 // labelsForProvider returns the labels of a BGPProvider as a labels.Set for selector matching.

--- a/test/e2e/Taskfile.yml
+++ b/test/e2e/Taskfile.yml
@@ -67,7 +67,7 @@ tasks:
       - docker build -t {{.BGP_IMG}} -f build/Dockerfile .
 
   images-build-gobgpd:
-    desc: Build the gobgpd sidecar image
+    desc: Build the gobgpd daemon image
     cmds:
       - |
         docker build --output type=docker -t {{.GOBGPD_IMG}} - <<'DOCKERFILE'
@@ -93,6 +93,7 @@ tasks:
       - task: deploy-cilium
       - task: deploy-crds
       - task: deploy-bgp-operator
+      - task: deploy-bgp-providers
       - task: deploy-bgp-instance
 
   deploy-cilium:
@@ -132,15 +133,23 @@ tasks:
           --timeout=60s
 
   deploy-bgp-operator:
-    desc: Deploy BGP operator DaemonSet with gobgpd sidecar
+    desc: Deploy BGP operator and gobgpd DaemonSets
     cmds:
-      # Apply the deploy kustomization (namespace, RBAC, ConfigMap, DaemonSet)
-      # using an overlay that sets the e2e-local image tags and LOCAL_ENDPOINT.
+      # Apply the overlay (namespace, RBAC, cosmos DaemonSet, gobgpd DaemonSet).
       - KUBECONFIG={{.KUBECONFIG}} kubectl apply -k {{.TASKFILE_DIR}}/overlay
       - KUBECONFIG={{.KUBECONFIG}} kubectl -n bgp-system wait
           --for=condition=Ready
           pod -l app.kubernetes.io/name=bgp
           --timeout=120s
+      - KUBECONFIG={{.KUBECONFIG}} kubectl -n bgp-system wait
+          --for=condition=Ready
+          pod -l app.kubernetes.io/name=gobgpd
+          --timeout=120s
+
+  deploy-bgp-providers:
+    desc: Apply BGPProvider manifests for each e2e worker node
+    cmds:
+      - KUBECONFIG={{.KUBECONFIG}} kubectl apply -f {{.TASKFILE_DIR}}/fixtures/bgpproviders.yaml
 
   deploy-bgp-instance:
     desc: Apply the default BGPInstance

--- a/test/e2e/fixtures/bgpproviders.yaml
+++ b/test/e2e/fixtures/bgpproviders.yaml
@@ -1,0 +1,35 @@
+apiVersion: providers.bgp.miloapis.com/v1alpha1
+kind: BGPProvider
+metadata:
+  name: bgp-e2e-worker-gobgp
+  labels:
+    bgp.miloapis.com/node: bgp-e2e-worker
+    bgp.miloapis.com/daemon: GoBGP
+spec:
+  type: GoBGP
+  gobgp:
+    endpoint: "localhost:50051"
+---
+apiVersion: providers.bgp.miloapis.com/v1alpha1
+kind: BGPProvider
+metadata:
+  name: bgp-e2e-worker2-gobgp
+  labels:
+    bgp.miloapis.com/node: bgp-e2e-worker2
+    bgp.miloapis.com/daemon: GoBGP
+spec:
+  type: GoBGP
+  gobgp:
+    endpoint: "localhost:50051"
+---
+apiVersion: providers.bgp.miloapis.com/v1alpha1
+kind: BGPProvider
+metadata:
+  name: bgp-e2e-worker3-gobgp
+  labels:
+    bgp.miloapis.com/node: bgp-e2e-worker3
+    bgp.miloapis.com/daemon: GoBGP
+spec:
+  type: GoBGP
+  gobgp:
+    endpoint: "localhost:50051"

--- a/test/e2e/overlay/gobgpd-config.yaml
+++ b/test/e2e/overlay/gobgpd-config.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: gobgp-config
+  name: gobgpd-config
   namespace: bgp-system
 data:
   gobgp.conf: |

--- a/test/e2e/overlay/gobgpd-daemonset.yaml
+++ b/test/e2e/overlay/gobgpd-daemonset.yaml
@@ -1,0 +1,65 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: gobgpd
+  namespace: bgp-system
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: gobgpd
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: gobgpd
+    spec:
+      hostNetwork: true
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: node-role.kubernetes.io/control-plane
+                    operator: DoesNotExist
+      initContainers:
+        - name: config-gen
+          image: busybox:1.36
+          command:
+            - /bin/sh
+            - -c
+            - |
+              NODE_IP=$(ip -6 addr show scope global | awk '/inet6/{print $2}' | cut -d/ -f1 | head -1)
+              if [ -z "$NODE_IP" ]; then
+                echo "ERROR: no global-scope IPv6 address found"
+                exit 1
+              fi
+              echo "Generating gobgp.conf with router-id=$NODE_IP"
+              sed "s/NODE_IP_PLACEHOLDER/$NODE_IP/g" /config-template/gobgp.conf > /config/gobgp.conf
+              cat /config/gobgp.conf
+          volumeMounts:
+            - name: config-template
+              mountPath: /config-template
+            - name: config
+              mountPath: /config
+      containers:
+        - name: gobgpd
+          image: gobgpd:e2e-local
+          imagePullPolicy: IfNotPresent
+          args: ["-f", "/config/gobgp.conf", "--log-level=debug", "-p"]
+          ports:
+            - containerPort: 1790
+              protocol: TCP
+              name: bgp
+            - containerPort: 50051
+              protocol: TCP
+              name: grpc
+          volumeMounts:
+            - name: config
+              mountPath: /config
+      volumes:
+        - name: config-template
+          configMap:
+            name: gobgpd-config
+        - name: config
+          emptyDir: {}
+      tolerations:
+        - operator: Exists

--- a/test/e2e/overlay/kustomization.yaml
+++ b/test/e2e/overlay/kustomization.yaml
@@ -1,21 +1,20 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-# Base deploy resources: namespace, RBAC, ConfigMap, DaemonSet
+# Base deploy resources: namespace, RBAC, DaemonSet
 resources:
   - ../../../config/deploy
+  - gobgpd-config.yaml
+  - gobgpd-daemonset.yaml
 
 # Override image tags for local e2e builds
 images:
   - name: ghcr.io/milo-os/bgp
     newTag: e2e-local
-  - name: gobgpd
+  - name: gobgpd:e2e-local
     newName: gobgpd
     newTag: e2e-local
 
-# Patch to set LOCAL_ENDPOINT to "$(NODE_NAME)" so each DaemonSet pod
-# registers its endpoint under the correct node-scoped name.
-# Uses JSON patch to modify only the specific env var without replacing the list.
 patches:
   - target:
       kind: DaemonSet
@@ -28,8 +27,6 @@ patches:
             valueFrom:
               fieldRef:
                 fieldPath: spec.nodeName
-          - name: LOCAL_ENDPOINT
-            value: "$(NODE_NAME)"
       - op: replace
         path: /spec/template/spec/containers/0/args
         value:

--- a/test/e2e/tests/bgp-advertisement/chainsaw-test.yaml
+++ b/test/e2e/tests/bgp-advertisement/chainsaw-test.yaml
@@ -82,23 +82,23 @@ spec:
         - script:
             content: |
               set -e
-              POD=$(kubectl -n bgp-system get pod \
-                -l app.kubernetes.io/name=bgp \
+              GPOD=$(kubectl -n bgp-system get pod \
+                -l app.kubernetes.io/name=gobgpd \
                 --field-selector spec.nodeName=bgp-e2e-worker \
                 -o jsonpath='{.items[0].metadata.name}')
-              echo "Waiting for GoBGP session in pod: $POD"
+              echo "Waiting for GoBGP session in pod: $GPOD"
 
               ATTEMPTS=0
               ESTABLISHED=0
               while [ "$ESTABLISHED" -lt 1 ] && [ "$ATTEMPTS" -lt 60 ]; do
-                ESTABLISHED=$(kubectl -n bgp-system exec "$POD" -c gobgpd -- \
+                ESTABLISHED=$(kubectl -n bgp-system exec "$GPOD" -- \
                   gobgp neighbor 2>/dev/null | grep -c "Establ" || true)
                 ATTEMPTS=$((ATTEMPTS+1))
                 [ "$ESTABLISHED" -lt 1 ] && sleep 5
               done
               if [ "$ESTABLISHED" -lt 1 ]; then
                 echo "ERROR: no BGP sessions reached Established"
-                kubectl -n bgp-system exec "$POD" -c gobgpd -- gobgp neighbor || true
+                kubectl -n bgp-system exec "$GPOD" -- gobgp neighbor || true
                 exit 1
               fi
               echo "OK: BGP session Established"
@@ -144,16 +144,15 @@ spec:
         - script:
             content: |
               set -e
-              # Get any bgp pod name to exec into gobgpd
-              POD=$(kubectl -n bgp-system get pod \
-                -l app.kubernetes.io/name=bgp \
+              GPOD=$(kubectl -n bgp-system get pod \
+                -l app.kubernetes.io/name=gobgpd \
                 -o jsonpath='{.items[0].metadata.name}')
-              echo "Checking GoBGP RIB in pod: $POD"
+              echo "Checking GoBGP RIB in pod: $GPOD"
 
               ATTEMPTS=0
               FOUND=0
               while [ "$FOUND" -eq 0 ] && [ "$ATTEMPTS" -lt 30 ]; do
-                OUTPUT=$(kubectl -n bgp-system exec "$POD" -c gobgpd -- \
+                OUTPUT=$(kubectl -n bgp-system exec "$GPOD" -- \
                   gobgp global rib -a ipv6 2>/dev/null || true)
                 echo "$OUTPUT" | grep -q "2001:db8:e2e::" && FOUND=1 || true
                 ATTEMPTS=$((ATTEMPTS+1))
@@ -162,7 +161,7 @@ spec:
 
               if [ "$FOUND" -eq 0 ]; then
                 echo "ERROR: prefix 2001:db8:e2e::/48 not found in GoBGP RIB"
-                kubectl -n bgp-system exec "$POD" -c gobgpd -- \
+                kubectl -n bgp-system exec "$GPOD" -- \
                   gobgp global rib -a ipv6 || true
                 exit 1
               fi
@@ -178,15 +177,15 @@ spec:
         - script:
             content: |
               set -e
-              POD=$(kubectl -n bgp-system get pod \
-                -l app.kubernetes.io/name=bgp \
+              GPOD=$(kubectl -n bgp-system get pod \
+                -l app.kubernetes.io/name=gobgpd \
                 -o jsonpath='{.items[0].metadata.name}')
-              echo "Verifying prefix withdrawn from GoBGP RIB in pod: $POD"
+              echo "Verifying prefix withdrawn from GoBGP RIB in pod: $GPOD"
 
               ATTEMPTS=0
               STILL_PRESENT=1
               while [ "$STILL_PRESENT" -eq 1 ] && [ "$ATTEMPTS" -lt 30 ]; do
-                OUTPUT=$(kubectl -n bgp-system exec "$POD" -c gobgpd -- \
+                OUTPUT=$(kubectl -n bgp-system exec "$GPOD" -- \
                   gobgp global rib -a ipv6 2>/dev/null || true)
                 echo "$OUTPUT" | grep -q "2001:db8:e2e::" && STILL_PRESENT=1 || STILL_PRESENT=0
                 ATTEMPTS=$((ATTEMPTS+1))

--- a/test/e2e/tests/bgp-peering/chainsaw-test.yaml
+++ b/test/e2e/tests/bgp-peering/chainsaw-test.yaml
@@ -48,16 +48,17 @@ spec:
               while [ "$COUNT" -lt 3 ] && [ "$ATTEMPTS" -lt 30 ]; do
                 COUNT=$(kubectl get bgpproviders \
                   -l bgp.miloapis.com/daemon=GoBGP \
-                  --no-headers 2>/dev/null | wc -l)
+                  -o jsonpath='{range .items[*]}{.status.conditions[?(@.type=="Ready")].status}{"\n"}{end}' \
+                  2>/dev/null | grep -c "^True$" || true)
                 ATTEMPTS=$((ATTEMPTS+1))
                 [ "$COUNT" -lt 3 ] && sleep 2
               done
               if [ "$COUNT" -lt 3 ]; then
-                echo "ERROR: only $COUNT/3 GoBGP BGPProviders ready after ${ATTEMPTS} attempts"
+                echo "ERROR: only $COUNT/3 GoBGP BGPProviders are Ready after ${ATTEMPTS} attempts"
                 kubectl get bgpproviders -o wide || true
                 exit 1
               fi
-              echo "OK: $COUNT GoBGP BGPProviders ready"
+              echo "OK: $COUNT GoBGP BGPProviders Ready"
 
     - name: create-bgp-sessions
       try:
@@ -218,15 +219,15 @@ spec:
               while [ "$ALL_OK" -eq 0 ] && [ "$ATTEMPTS" -lt 60 ]; do
                 ALL_OK=1
                 for WORKER in bgp-e2e-worker bgp-e2e-worker2 bgp-e2e-worker3; do
-                  POD=$(kubectl -n bgp-system get pod \
-                    -l app.kubernetes.io/name=bgp \
+                  GPOD=$(kubectl -n bgp-system get pod \
+                    -l app.kubernetes.io/name=gobgpd \
                     --field-selector "spec.nodeName=${WORKER}" \
                     -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || true)
-                  if [ -z "$POD" ]; then
+                  if [ -z "$GPOD" ]; then
                     ALL_OK=0
                     break
                   fi
-                  ESTABLISHED=$(kubectl -n bgp-system exec "$POD" -c gobgpd -- \
+                  ESTABLISHED=$(kubectl -n bgp-system exec "$GPOD" -- \
                     gobgp neighbor 2>/dev/null | grep -c "Establ" || true)
                   if [ "$ESTABLISHED" -lt 2 ]; then
                     ALL_OK=0
@@ -239,12 +240,12 @@ spec:
               if [ "$ALL_OK" -eq 0 ]; then
                 echo "ERROR: not all workers have 2+ established GoBGP sessions"
                 for WORKER in bgp-e2e-worker bgp-e2e-worker2 bgp-e2e-worker3; do
-                  POD=$(kubectl -n bgp-system get pod \
-                    -l app.kubernetes.io/name=bgp \
+                  GPOD=$(kubectl -n bgp-system get pod \
+                    -l app.kubernetes.io/name=gobgpd \
                     --field-selector "spec.nodeName=${WORKER}" \
                     -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || true)
-                  echo "--- $WORKER ($POD) ---"
-                  [ -n "$POD" ] && kubectl -n bgp-system exec "$POD" -c gobgpd -- \
+                  echo "--- $WORKER ($GPOD) ---"
+                  [ -n "$GPOD" ] && kubectl -n bgp-system exec "$GPOD" -- \
                     gobgp neighbor 2>/dev/null || true
                 done
                 exit 1

--- a/test/e2e/tests/bgp-route-policy/chainsaw-test.yaml
+++ b/test/e2e/tests/bgp-route-policy/chainsaw-test.yaml
@@ -82,23 +82,23 @@ spec:
         - script:
             content: |
               set -e
-              POD=$(kubectl -n bgp-system get pod \
-                -l app.kubernetes.io/name=bgp \
+              GPOD=$(kubectl -n bgp-system get pod \
+                -l app.kubernetes.io/name=gobgpd \
                 --field-selector spec.nodeName=bgp-e2e-worker \
                 -o jsonpath='{.items[0].metadata.name}')
-              echo "Waiting for GoBGP session in pod: $POD"
+              echo "Waiting for GoBGP session in pod: $GPOD"
 
               ATTEMPTS=0
               ESTABLISHED=0
               while [ "$ESTABLISHED" -lt 1 ] && [ "$ATTEMPTS" -lt 60 ]; do
-                ESTABLISHED=$(kubectl -n bgp-system exec "$POD" -c gobgpd -- \
+                ESTABLISHED=$(kubectl -n bgp-system exec "$GPOD" -- \
                   gobgp neighbor 2>/dev/null | grep -c "Establ" || true)
                 ATTEMPTS=$((ATTEMPTS+1))
                 [ "$ESTABLISHED" -lt 1 ] && sleep 5
               done
               if [ "$ESTABLISHED" -lt 1 ]; then
                 echo "ERROR: no BGP sessions reached Established"
-                kubectl -n bgp-system exec "$POD" -c gobgpd -- gobgp neighbor || true
+                kubectl -n bgp-system exec "$GPOD" -- gobgp neighbor || true
                 exit 1
               fi
               echo "OK: BGP session Established"

--- a/test/e2e/tests/session-lifecycle/chainsaw-test.yaml
+++ b/test/e2e/tests/session-lifecycle/chainsaw-test.yaml
@@ -95,23 +95,23 @@ spec:
         - script:
             content: |
               set -e
-              POD=$(kubectl -n bgp-system get pod \
-                -l app.kubernetes.io/name=bgp \
+              GPOD=$(kubectl -n bgp-system get pod \
+                -l app.kubernetes.io/name=gobgpd \
                 --field-selector spec.nodeName=bgp-e2e-worker2 \
                 -o jsonpath='{.items[0].metadata.name}')
-              echo "Waiting for GoBGP session in pod: $POD"
+              echo "Waiting for GoBGP session in pod: $GPOD"
 
               ATTEMPTS=0
               ESTABLISHED=0
               while [ "$ESTABLISHED" -lt 1 ] && [ "$ATTEMPTS" -lt 60 ]; do
-                ESTABLISHED=$(kubectl -n bgp-system exec "$POD" -c gobgpd -- \
+                ESTABLISHED=$(kubectl -n bgp-system exec "$GPOD" -- \
                   gobgp neighbor 2>/dev/null | grep -c "Establ" || true)
                 ATTEMPTS=$((ATTEMPTS+1))
                 [ "$ESTABLISHED" -lt 1 ] && sleep 5
               done
               if [ "$ESTABLISHED" -lt 1 ]; then
                 echo "ERROR: no BGP session reached Established on bgp-e2e-worker2"
-                kubectl -n bgp-system exec "$POD" -c gobgpd -- gobgp neighbor || true
+                kubectl -n bgp-system exec "$GPOD" -- gobgp neighbor || true
                 exit 1
               fi
               echo "OK: BGP session Established"
@@ -125,12 +125,12 @@ spec:
               W3=$(kubectl get node bgp-e2e-worker3 \
                 -o jsonpath='{range .status.addresses[?(@.type=="InternalIP")]}{.address}{"\n"}{end}' \
                 | grep ':' | head -1)
-              POD=$(kubectl -n bgp-system get pod \
-                -l app.kubernetes.io/name=bgp \
+              GPOD=$(kubectl -n bgp-system get pod \
+                -l app.kubernetes.io/name=gobgpd \
                 --field-selector spec.nodeName=bgp-e2e-worker2 \
                 -o jsonpath='{.items[0].metadata.name}')
-              echo "Checking GoBGP peer $W3 in pod $POD (on bgp-e2e-worker2)"
-              kubectl -n bgp-system exec "$POD" -c gobgpd -- \
+              echo "Checking GoBGP peer $W3 in pod $GPOD (on bgp-e2e-worker2)"
+              kubectl -n bgp-system exec "$GPOD" -- \
                 gobgp neighbor | grep -q "${W3}"
               echo "OK: peer $W3 present in GoBGP"
 

--- a/test/e2e/tests/system-readiness/chainsaw-test.yaml
+++ b/test/e2e/tests/system-readiness/chainsaw-test.yaml
@@ -17,21 +17,35 @@ spec:
               status:
                 (numberReady == desiredNumberScheduled): true
 
-    - name: bgp-pods-two-containers
+    - name: bgp-pods-ready
       try:
-        # Each pod runs bgp + gobgpd — verify at least one pod has both containers ready.
         - script:
             content: |
               set -e
               READY=$(kubectl -n bgp-system get pods \
                 -l app.kubernetes.io/name=bgp \
-                -o jsonpath='{range .items[*]}{.status.containerStatuses[*].ready}{"\n"}{end}' \
-                | grep -c "true true" || true)
+                -o jsonpath='{range .items[*]}{.status.containerStatuses[0].ready}{"\n"}{end}' \
+                | grep -c "^true$" || true)
               if [ "$READY" -eq 0 ]; then
-                echo "ERROR: no bgp pods found with both containers ready (bgp + gobgpd)"
+                echo "ERROR: no bgp pods found with the bgp container ready"
                 exit 1
               fi
-              echo "OK: $READY pod(s) with both containers ready"
+              echo "OK: $READY bgp pod(s) ready"
+
+    - name: gobgpd-pods-ready
+      try:
+        - script:
+            content: |
+              set -e
+              READY=$(kubectl -n bgp-system get pods \
+                -l app.kubernetes.io/name=gobgpd \
+                -o jsonpath='{range .items[*]}{.status.containerStatuses[0].ready}{"\n"}{end}' \
+                | grep -c "^true$" || true)
+              if [ "$READY" -eq 0 ]; then
+                echo "ERROR: no gobgpd pods found ready"
+                exit 1
+              fi
+              echo "OK: $READY gobgpd pod(s) ready"
 
     - name: crds-established
       try:
@@ -108,10 +122,10 @@ spec:
               status:
                 (conditions[?type=='Established'].status | [0]): "True"
 
-    - name: bgp-providers-bootstrapped
+    - name: bgp-providers-ready
       try:
-        # ProviderReconciler auto-bootstraps one BGPProvider per node at startup.
-        # Expect one GoBGP provider per worker node (3 workers in the e2e cluster).
+        # One BGPProvider per worker node is applied by the deploy step.
+        # Wait for all 3 to report Ready=True (daemon health probe passed).
         - script:
             content: |
               set -e
@@ -120,13 +134,14 @@ spec:
               while [ "$COUNT" -lt 3 ] && [ "$ATTEMPTS" -lt 30 ]; do
                 COUNT=$(kubectl get bgpproviders \
                   -l bgp.miloapis.com/daemon=GoBGP \
-                  --no-headers 2>/dev/null | wc -l)
+                  -o jsonpath='{range .items[*]}{.status.conditions[?(@.type=="Ready")].status}{"\n"}{end}' \
+                  2>/dev/null | grep -c "^True$" || true)
                 ATTEMPTS=$((ATTEMPTS+1))
                 [ "$COUNT" -lt 3 ] && sleep 2
               done
               if [ "$COUNT" -lt 3 ]; then
-                echo "ERROR: only $COUNT/3 GoBGP BGPProviders bootstrapped after ${ATTEMPTS} attempts"
+                echo "ERROR: only $COUNT/3 GoBGP BGPProviders are Ready after ${ATTEMPTS} attempts"
                 kubectl get bgpproviders -o wide || true
                 exit 1
               fi
-              echo "OK: $COUNT GoBGP BGPProviders bootstrapped"
+              echo "OK: $COUNT GoBGP BGPProviders Ready"


### PR DESCRIPTION
## Summary

- Cosmos no longer manages GoBGP as a sidecar container. BGP daemons (GoBGP, FRR) are expected to run independently; cosmos connects to them via the endpoint configured in `BGPProvider` resources.
- Removed the loopback-only endpoint restriction — `BGPProvider` objects may now point to any reachable gRPC endpoint.
- Removed `bootstrapLocalProviders` and the startup hook that auto-created `BGPProvider` objects; these must now be applied by the operator deploying the system.
- E2E suite updated to deploy GoBGP as a standalone DaemonSet and apply `BGPProvider` fixtures, replacing all `kubectl exec -c gobgpd` calls with exec targeting the gobgpd pod by node selector.

## Changes

**Controller (`internal/controller/`)**
- Remove `bootstrapLocalProviders`, `bootstrapRunnable`, `buildProviderSpec`, `isLoopback`, and `LabelManagedByBootstrap`
- Remove loopback-only validation from `ProviderReconciler.Reconcile`

**Deployment (`config/deploy/`)**
- Remove `gobgpd` sidecar container, `config-gen` init container, and `gobgp-config` ConfigMap from the base DaemonSet
- Remove `gobgp-config.yaml` entirely

**E2E (`test/e2e/`)**
- Add `overlay/gobgpd-daemonset.yaml` and `overlay/gobgpd-config.yaml` — GoBGP as a standalone DaemonSet for the test cluster
- Add `fixtures/bgpproviders.yaml` — static `BGPProvider` objects for the three e2e worker nodes
- Add `deploy-bgp-providers` Taskfile step; wire into the `deploy` sequence
- Fix `system-readiness`: two-container check → per-DaemonSet readiness checks; bootstrap wait → `Ready=True` condition wait
- Fix `bgp-peering`, `bgp-advertisement`, `bgp-route-policy`, `session-lifecycle`: all `exec -c gobgpd` replaced with exec targeting `app.kubernetes.io/name=gobgpd` pods

## Test plan

- [ ] `go build ./...` and `go vet ./...` pass clean
- [ ] `task e2e` (or `task -d test/e2e default`) passes the full Chainsaw suite against a fresh kind cluster
- [ ] `system-readiness`: both `bgp-pods-ready` and `gobgpd-pods-ready` steps pass; `bgp-providers-ready` reports 3/3 Ready
- [ ] `bgp-peering`, `bgp-advertisement`, `bgp-route-policy`, `session-lifecycle`: all steps pass with exec targeting gobgpd pods

🤖 Generated with [Claude Code](https://claude.com/claude-code)