### PR TITLE
chore: upgrade to Go 1.26

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,7 +7,7 @@ on:
     branches: [main]
 
 env:
-  GO_VERSION: '1.24'
+  GO_VERSION: '1.26'
 
 jobs:
   build:

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.24-alpine AS build
+FROM golang:1.26-alpine AS build
 WORKDIR /app
 COPY go.mod go.sum ./
 RUN go mod download

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module go.miloapis.com/bgp
 
-go 1.24.5
+go 1.26
 
 require (
 	github.com/osrg/gobgp/v4 v4.5.0
@@ -9,7 +9,6 @@ require (
 	github.com/vishvananda/netlink v1.3.2-0.20250622222046-78aca1ace529
 	golang.org/x/sys v0.39.0
 	google.golang.org/grpc v1.79.3
-	google.golang.org/protobuf v1.36.10
 	k8s.io/api v0.33.0
 	k8s.io/apimachinery v0.33.0
 	k8s.io/client-go v0.33.0
@@ -55,6 +54,7 @@ require (
 	golang.org/x/time v0.12.0 // indirect
 	gomodules.xyz/jsonpatch/v2 v2.4.0 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20251202230838-ff82c1b0f217 // indirect
+	google.golang.org/protobuf v1.36.10 // indirect
 	gopkg.in/evanphx/json-patch.v4 v4.12.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/test/e2e/Taskfile.yml
+++ b/test/e2e/Taskfile.yml
@@ -71,7 +71,7 @@ tasks:
     cmds:
       - |
         docker build --output type=docker -t {{.GOBGPD_IMG}} - <<'DOCKERFILE'
-        FROM golang:1.24-alpine AS build
+        FROM golang:1.26-alpine AS build
         RUN apk add --no-cache git
         RUN go install github.com/osrg/gobgp/v4/cmd/gobgpd@v4.5.0
         RUN go install github.com/osrg/gobgp/v4/cmd/gobgp@v4.5.0


### PR DESCRIPTION
## Summary

- Bump `go` directive in `go.mod` from `1.24.5` to `1.26`
- Update CI workflow `GO_VERSION` from `1.24` to `1.26`
- Update operator `build/Dockerfile` base image from `golang:1.24-alpine` to `golang:1.26-alpine`
- Update inline gobgpd build image in `test/e2e/Taskfile.yml` from `golang:1.24-alpine` to `golang:1.26-alpine`
- `go mod tidy` reclassifies `google.golang.org/protobuf` as indirect under the new toolchain

## Test plan

- [x] `go build ./...` — clean under Go 1.26.4
- [x] `go vet ./...` — no issues
- [x] `go test ./...` — all unit tests pass
- [x] Full e2e suite (7 chainsaw tests) — all pass under the Go 1.26-built operator image

🤖 Generated with [Claude Code](https://claude.com/claude-code)