### PR TITLE
chore: rename Go module from go.miloapis.com/bgp to go.miloapis.com/cosmos

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -3,10 +3,10 @@ WORKDIR /app
 COPY go.mod go.sum ./
 RUN go mod download
 COPY . .
-RUN CGO_ENABLED=0 go build -o /bgp ./cmd/bgp
+RUN CGO_ENABLED=0 go build -o /cosmos ./cmd/cosmos
 
 FROM alpine:3.19
 RUN adduser -D -u 65532 nonroot
-COPY --from=build /bgp /usr/local/bin/bgp
+COPY --from=build /cosmos /usr/local/bin/cosmos
 USER 65532:65532
-ENTRYPOINT ["bgp"]
+ENTRYPOINT ["cosmos"]

--- a/cmd/cosmos/main.go
+++ b/cmd/cosmos/main.go
@@ -30,7 +30,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	ctrlconfig "sigs.k8s.io/controller-runtime/pkg/client/config"
 
-	bgpcontroller "go.miloapis.com/bgp/internal/controller"
+	bgpcontroller "go.miloapis.com/cosmos/internal/controller"
 )
 
 func main() {
@@ -50,9 +50,9 @@ func newRootCommand() *cobra.Command {
 	opts := &options{}
 
 	cmd := &cobra.Command{
-		Use:   "bgp",
-		Short: "BGP operator — reconciles BGP CRDs against local BGP daemons",
-		Long: `The BGP operator reconciles BGP CRDs against independently-running BGP daemons.
+		Use:   "cosmos",
+		Short: "Cosmos operator — reconciles network CRDs against local BGP daemons",
+		Long: `Cosmos reconciles network CRDs against independently-running BGP daemons.
 It reads its cluster role from the cosmos-config ConfigMap in cosmos-system and
 reconciles BGPProvider, BGPInstance, BGPPeer, BGPAdvertisement, BGPRoutePolicy,
 BGPSession, and BGPExternalPeer CRDs. BGPProvider resources specify the gRPC
@@ -84,7 +84,7 @@ func run(ctx context.Context, opts *options) error {
 	// Read NODE_NAME from Downward API environment variable.
 	nodeName := os.Getenv("NODE_NAME")
 	if nodeName == "" {
-		log.Printf("bgp: NODE_NAME not set — provider auto-bootstrap disabled")
+		log.Printf("cosmos: NODE_NAME not set — provider auto-bootstrap disabled")
 	}
 
 	// Resolve clusterRole: use the flag value directly when set; otherwise read from
@@ -100,7 +100,7 @@ func run(ctx context.Context, opts *options) error {
 		return fmt.Errorf("invalid --cluster-role %q: must be one of pop, infra, management", clusterRole)
 	}
 
-	log.Printf("bgp: starting (clusterRole=%s node=%s)", clusterRole, nodeName)
+	log.Printf("cosmos: starting (clusterRole=%s node=%s)", clusterRole, nodeName)
 
 	return bgpcontroller.Run(ctx, opts.metricsAddr, opts.healthAddr, clusterRole, nodeName)
 }

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module go.miloapis.com/bgp
+module go.miloapis.com/cosmos
 
 go 1.26
 

--- a/internal/controller/advertisement_reconciler.go
+++ b/internal/controller/advertisement_reconciler.go
@@ -18,9 +18,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
-	providersv1alpha1 "go.miloapis.com/bgp/api/providers/v1alpha1"
-	bgpv1alpha1 "go.miloapis.com/bgp/api/bgp/v1alpha1"
-	"go.miloapis.com/bgp/internal/provider"
+	providersv1alpha1 "go.miloapis.com/cosmos/api/providers/v1alpha1"
+	bgpv1alpha1 "go.miloapis.com/cosmos/api/bgp/v1alpha1"
+	"go.miloapis.com/cosmos/internal/provider"
 )
 
 // AdvertisementReconciler reconciles BGPAdvertisement resources.

--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -15,9 +15,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 
-	providersv1alpha1 "go.miloapis.com/bgp/api/providers/v1alpha1"
-	bgpv1alpha1 "go.miloapis.com/bgp/api/bgp/v1alpha1"
-	"go.miloapis.com/bgp/internal/provider"
+	providersv1alpha1 "go.miloapis.com/cosmos/api/providers/v1alpha1"
+	bgpv1alpha1 "go.miloapis.com/cosmos/api/bgp/v1alpha1"
+	"go.miloapis.com/cosmos/internal/provider"
 )
 
 // scheme holds the runtime.Scheme for all types used by the manager.

--- a/internal/controller/externalpeer_reconciler.go
+++ b/internal/controller/externalpeer_reconciler.go
@@ -14,7 +14,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
-	bgpv1alpha1 "go.miloapis.com/bgp/api/bgp/v1alpha1"
+	bgpv1alpha1 "go.miloapis.com/cosmos/api/bgp/v1alpha1"
 )
 
 // ExternalPeerReconciler reconciles BGPExternalPeer resources.

--- a/internal/controller/instance_reconciler.go
+++ b/internal/controller/instance_reconciler.go
@@ -20,9 +20,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
-	providersv1alpha1 "go.miloapis.com/bgp/api/providers/v1alpha1"
-	bgpv1alpha1 "go.miloapis.com/bgp/api/bgp/v1alpha1"
-	"go.miloapis.com/bgp/internal/provider"
+	providersv1alpha1 "go.miloapis.com/cosmos/api/providers/v1alpha1"
+	bgpv1alpha1 "go.miloapis.com/cosmos/api/bgp/v1alpha1"
+	"go.miloapis.com/cosmos/internal/provider"
 )
 
 // InstanceReconciler reconciles BGPInstance resources.

--- a/internal/controller/instance_reconciler_test.go
+++ b/internal/controller/instance_reconciler_test.go
@@ -7,9 +7,9 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
-	providersv1alpha1 "go.miloapis.com/bgp/api/providers/v1alpha1"
-	bgpv1alpha1 "go.miloapis.com/bgp/api/bgp/v1alpha1"
-	"go.miloapis.com/bgp/internal/provider"
+	providersv1alpha1 "go.miloapis.com/cosmos/api/providers/v1alpha1"
+	bgpv1alpha1 "go.miloapis.com/cosmos/api/bgp/v1alpha1"
+	"go.miloapis.com/cosmos/internal/provider"
 )
 
 // stubProvider records the most recent ConfigureSpeaker call for inspection.

--- a/internal/controller/peer_reconciler.go
+++ b/internal/controller/peer_reconciler.go
@@ -19,9 +19,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
-	providersv1alpha1 "go.miloapis.com/bgp/api/providers/v1alpha1"
-	bgpv1alpha1 "go.miloapis.com/bgp/api/bgp/v1alpha1"
-	"go.miloapis.com/bgp/internal/provider"
+	providersv1alpha1 "go.miloapis.com/cosmos/api/providers/v1alpha1"
+	bgpv1alpha1 "go.miloapis.com/cosmos/api/bgp/v1alpha1"
+	"go.miloapis.com/cosmos/internal/provider"
 )
 
 // PeerReconciler reconciles BGPPeer resources.

--- a/internal/controller/provider_reconciler.go
+++ b/internal/controller/provider_reconciler.go
@@ -17,11 +17,11 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
-	providersv1alpha1 "go.miloapis.com/bgp/api/providers/v1alpha1"
-	bgpv1alpha1 "go.miloapis.com/bgp/api/bgp/v1alpha1"
-	"go.miloapis.com/bgp/internal/provider"
-	frrprovider "go.miloapis.com/bgp/internal/provider/frr"
-	gobgpprovider "go.miloapis.com/bgp/internal/provider/gobgp"
+	providersv1alpha1 "go.miloapis.com/cosmos/api/providers/v1alpha1"
+	bgpv1alpha1 "go.miloapis.com/cosmos/api/bgp/v1alpha1"
+	"go.miloapis.com/cosmos/internal/provider"
+	frrprovider "go.miloapis.com/cosmos/internal/provider/frr"
+	gobgpprovider "go.miloapis.com/cosmos/internal/provider/gobgp"
 )
 
 const (

--- a/internal/controller/routepolicy_reconciler.go
+++ b/internal/controller/routepolicy_reconciler.go
@@ -18,9 +18,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
-	providersv1alpha1 "go.miloapis.com/bgp/api/providers/v1alpha1"
-	bgpv1alpha1 "go.miloapis.com/bgp/api/bgp/v1alpha1"
-	"go.miloapis.com/bgp/internal/provider"
+	providersv1alpha1 "go.miloapis.com/cosmos/api/providers/v1alpha1"
+	bgpv1alpha1 "go.miloapis.com/cosmos/api/bgp/v1alpha1"
+	"go.miloapis.com/cosmos/internal/provider"
 )
 
 // RoutePolicyReconciler reconciles BGPRoutePolicy resources.

--- a/internal/controller/session_reconciler.go
+++ b/internal/controller/session_reconciler.go
@@ -16,8 +16,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
-	providersv1alpha1 "go.miloapis.com/bgp/api/providers/v1alpha1"
-	bgpv1alpha1 "go.miloapis.com/bgp/api/bgp/v1alpha1"
+	providersv1alpha1 "go.miloapis.com/cosmos/api/providers/v1alpha1"
+	bgpv1alpha1 "go.miloapis.com/cosmos/api/bgp/v1alpha1"
 )
 
 // SessionReconciler reconciles BGPSession resources.

--- a/internal/provider/frr/provider.go
+++ b/internal/provider/frr/provider.go
@@ -31,7 +31,7 @@ import (
 	"os/exec"
 	"strings"
 
-	"go.miloapis.com/bgp/internal/provider"
+	"go.miloapis.com/cosmos/internal/provider"
 )
 
 // FRRCapabilities are the compile-time capabilities of the FRR provider.

--- a/internal/provider/gobgp/provider.go
+++ b/internal/provider/gobgp/provider.go
@@ -28,7 +28,7 @@ import (
 	"google.golang.org/grpc/credentials/insecure"
 	grpcstatus "google.golang.org/grpc/status"
 
-	"go.miloapis.com/bgp/internal/provider"
+	"go.miloapis.com/cosmos/internal/provider"
 )
 
 // GoBGPCapabilities are the compile-time capabilities of the GoBGP provider.

--- a/internal/provider/gobgp/provider_test.go
+++ b/internal/provider/gobgp/provider_test.go
@@ -6,7 +6,7 @@ import (
 
 	gobgpapi "github.com/osrg/gobgp/v4/api"
 
-	"go.miloapis.com/bgp/internal/provider"
+	"go.miloapis.com/cosmos/internal/provider"
 )
 
 func TestAfiSafiFromStrings(t *testing.T) {

--- a/internal/routesync/route_watcher.go
+++ b/internal/routesync/route_watcher.go
@@ -14,7 +14,7 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 
-	bgpnetlink "go.miloapis.com/bgp/internal/netlink"
+	bgpnetlink "go.miloapis.com/cosmos/internal/netlink"
 )
 
 const routeWatchRetryInterval = 2 * time.Second


### PR DESCRIPTION
## Summary

- Renames the Go module from `go.miloapis.com/bgp` to `go.miloapis.com/cosmos` in `go.mod`
- Updates all internal import paths across 14 source files
- Renames `cmd/bgp/` entrypoint directory to `cmd/cosmos/`
- Updates `build/Dockerfile` build output, install path, and `ENTRYPOINT` from `bgp` to `cosmos`
- Updates cobra command `Use`, `Short`, and `Long` descriptions, and log prefixes

Kubernetes API groups (`bgp.miloapis.com`, `providers.bgp.miloapis.com`, `vpc.miloapis.com`) and CRD/deploy manifests are unchanged — they are independent of the Go module path.

## Test plan

- [ ] `go build ./...` passes
- [ ] `go test ./...` passes
- [ ] Container image builds with `task image`

🤖 Generated with [Claude Code](https://claude.com/claude-code)