### PR TITLE
fix: Guard StopBgp against uninitialised GoBGP v4 daemon (Asn=0)

### DIFF
--- a/internal/provider/gobgp/provider.go
+++ b/internal/provider/gobgp/provider.go
@@ -115,7 +115,10 @@ func (p *Provider) ConfigureSpeaker(ctx context.Context, spec provider.SpeakerSp
 		return false, fmt.Errorf("gobgp: ConfigureSpeaker GetBgp: %w", err)
 	}
 
-	needsRestart := resp == nil || resp.Global == nil
+	// GoBGP v4 returns Asn=0 (not NotFound) when the BGP engine has not been
+	// started yet. Treat Asn==0 as uninitialised — do not call StopBgp, which
+	// would terminate the gobgpd process.
+	needsRestart := resp == nil || resp.Global == nil || resp.Global.Asn == 0
 	if !needsRestart {
 		g := resp.Global
 		needsRestart = g.Asn != uint32(spec.ASNumber) ||
@@ -128,7 +131,7 @@ func (p *Provider) ConfigureSpeaker(ctx context.Context, spec provider.SpeakerSp
 	}
 
 	// Stop the current BGP instance if one is running.
-	if resp != nil && resp.Global != nil {
+	if resp != nil && resp.Global != nil && resp.Global.Asn != 0 {
 		if _, err := p.client.StopBgp(ctx, &gobgpapi.StopBgpRequest{}); err != nil {
 			return false, fmt.Errorf("gobgp: ConfigureSpeaker StopBgp: %w", err)
 		}

--- a/internal/provider/gobgp/provider_test.go
+++ b/internal/provider/gobgp/provider_test.go
@@ -5,9 +5,189 @@ import (
 	"testing"
 
 	gobgpapi "github.com/osrg/gobgp/v4/api"
+	"google.golang.org/grpc"
 
 	"go.miloapis.com/bgp/internal/provider"
 )
+
+// fakeGoBgpClient implements gobgpapi.GoBgpServiceClient for unit tests.
+// Only GetBgp, StopBgp, and StartBgp have real logic; all other methods
+// return nil, nil so that ConfigureSpeaker can be tested without a live daemon.
+type fakeGoBgpClient struct {
+	getBgpFn    func(context.Context, *gobgpapi.GetBgpRequest, ...grpc.CallOption) (*gobgpapi.GetBgpResponse, error)
+	stopBgpN    int
+	startBgpReq *gobgpapi.StartBgpRequest
+}
+
+func (f *fakeGoBgpClient) GetBgp(ctx context.Context, in *gobgpapi.GetBgpRequest, opts ...grpc.CallOption) (*gobgpapi.GetBgpResponse, error) {
+	return f.getBgpFn(ctx, in, opts...)
+}
+func (f *fakeGoBgpClient) StopBgp(_ context.Context, _ *gobgpapi.StopBgpRequest, _ ...grpc.CallOption) (*gobgpapi.StopBgpResponse, error) {
+	f.stopBgpN++
+	return nil, nil
+}
+func (f *fakeGoBgpClient) StartBgp(_ context.Context, in *gobgpapi.StartBgpRequest, _ ...grpc.CallOption) (*gobgpapi.StartBgpResponse, error) {
+	f.startBgpReq = in
+	return nil, nil
+}
+
+// Stub implementations — not exercised by ConfigureSpeaker tests.
+func (f *fakeGoBgpClient) WatchEvent(_ context.Context, _ *gobgpapi.WatchEventRequest, _ ...grpc.CallOption) (grpc.ServerStreamingClient[gobgpapi.WatchEventResponse], error) {
+	return nil, nil
+}
+func (f *fakeGoBgpClient) AddPeer(_ context.Context, _ *gobgpapi.AddPeerRequest, _ ...grpc.CallOption) (*gobgpapi.AddPeerResponse, error) {
+	return nil, nil
+}
+func (f *fakeGoBgpClient) DeletePeer(_ context.Context, _ *gobgpapi.DeletePeerRequest, _ ...grpc.CallOption) (*gobgpapi.DeletePeerResponse, error) {
+	return nil, nil
+}
+func (f *fakeGoBgpClient) ListPeer(_ context.Context, _ *gobgpapi.ListPeerRequest, _ ...grpc.CallOption) (grpc.ServerStreamingClient[gobgpapi.ListPeerResponse], error) {
+	return nil, nil
+}
+func (f *fakeGoBgpClient) UpdatePeer(_ context.Context, _ *gobgpapi.UpdatePeerRequest, _ ...grpc.CallOption) (*gobgpapi.UpdatePeerResponse, error) {
+	return nil, nil
+}
+func (f *fakeGoBgpClient) ResetPeer(_ context.Context, _ *gobgpapi.ResetPeerRequest, _ ...grpc.CallOption) (*gobgpapi.ResetPeerResponse, error) {
+	return nil, nil
+}
+func (f *fakeGoBgpClient) ShutdownPeer(_ context.Context, _ *gobgpapi.ShutdownPeerRequest, _ ...grpc.CallOption) (*gobgpapi.ShutdownPeerResponse, error) {
+	return nil, nil
+}
+func (f *fakeGoBgpClient) EnablePeer(_ context.Context, _ *gobgpapi.EnablePeerRequest, _ ...grpc.CallOption) (*gobgpapi.EnablePeerResponse, error) {
+	return nil, nil
+}
+func (f *fakeGoBgpClient) DisablePeer(_ context.Context, _ *gobgpapi.DisablePeerRequest, _ ...grpc.CallOption) (*gobgpapi.DisablePeerResponse, error) {
+	return nil, nil
+}
+func (f *fakeGoBgpClient) AddPeerGroup(_ context.Context, _ *gobgpapi.AddPeerGroupRequest, _ ...grpc.CallOption) (*gobgpapi.AddPeerGroupResponse, error) {
+	return nil, nil
+}
+func (f *fakeGoBgpClient) DeletePeerGroup(_ context.Context, _ *gobgpapi.DeletePeerGroupRequest, _ ...grpc.CallOption) (*gobgpapi.DeletePeerGroupResponse, error) {
+	return nil, nil
+}
+func (f *fakeGoBgpClient) ListPeerGroup(_ context.Context, _ *gobgpapi.ListPeerGroupRequest, _ ...grpc.CallOption) (grpc.ServerStreamingClient[gobgpapi.ListPeerGroupResponse], error) {
+	return nil, nil
+}
+func (f *fakeGoBgpClient) UpdatePeerGroup(_ context.Context, _ *gobgpapi.UpdatePeerGroupRequest, _ ...grpc.CallOption) (*gobgpapi.UpdatePeerGroupResponse, error) {
+	return nil, nil
+}
+func (f *fakeGoBgpClient) AddDynamicNeighbor(_ context.Context, _ *gobgpapi.AddDynamicNeighborRequest, _ ...grpc.CallOption) (*gobgpapi.AddDynamicNeighborResponse, error) {
+	return nil, nil
+}
+func (f *fakeGoBgpClient) ListDynamicNeighbor(_ context.Context, _ *gobgpapi.ListDynamicNeighborRequest, _ ...grpc.CallOption) (grpc.ServerStreamingClient[gobgpapi.ListDynamicNeighborResponse], error) {
+	return nil, nil
+}
+func (f *fakeGoBgpClient) DeleteDynamicNeighbor(_ context.Context, _ *gobgpapi.DeleteDynamicNeighborRequest, _ ...grpc.CallOption) (*gobgpapi.DeleteDynamicNeighborResponse, error) {
+	return nil, nil
+}
+func (f *fakeGoBgpClient) AddPath(_ context.Context, _ *gobgpapi.AddPathRequest, _ ...grpc.CallOption) (*gobgpapi.AddPathResponse, error) {
+	return nil, nil
+}
+func (f *fakeGoBgpClient) DeletePath(_ context.Context, _ *gobgpapi.DeletePathRequest, _ ...grpc.CallOption) (*gobgpapi.DeletePathResponse, error) {
+	return nil, nil
+}
+func (f *fakeGoBgpClient) ListPath(_ context.Context, _ *gobgpapi.ListPathRequest, _ ...grpc.CallOption) (grpc.ServerStreamingClient[gobgpapi.ListPathResponse], error) {
+	return nil, nil
+}
+func (f *fakeGoBgpClient) AddPathStream(_ context.Context, _ ...grpc.CallOption) (grpc.ClientStreamingClient[gobgpapi.AddPathStreamRequest, gobgpapi.AddPathStreamResponse], error) {
+	return nil, nil
+}
+func (f *fakeGoBgpClient) GetTable(_ context.Context, _ *gobgpapi.GetTableRequest, _ ...grpc.CallOption) (*gobgpapi.GetTableResponse, error) {
+	return nil, nil
+}
+func (f *fakeGoBgpClient) AddVrf(_ context.Context, _ *gobgpapi.AddVrfRequest, _ ...grpc.CallOption) (*gobgpapi.AddVrfResponse, error) {
+	return nil, nil
+}
+func (f *fakeGoBgpClient) DeleteVrf(_ context.Context, _ *gobgpapi.DeleteVrfRequest, _ ...grpc.CallOption) (*gobgpapi.DeleteVrfResponse, error) {
+	return nil, nil
+}
+func (f *fakeGoBgpClient) ListVrf(_ context.Context, _ *gobgpapi.ListVrfRequest, _ ...grpc.CallOption) (grpc.ServerStreamingClient[gobgpapi.ListVrfResponse], error) {
+	return nil, nil
+}
+func (f *fakeGoBgpClient) AddPolicy(_ context.Context, _ *gobgpapi.AddPolicyRequest, _ ...grpc.CallOption) (*gobgpapi.AddPolicyResponse, error) {
+	return nil, nil
+}
+func (f *fakeGoBgpClient) DeletePolicy(_ context.Context, _ *gobgpapi.DeletePolicyRequest, _ ...grpc.CallOption) (*gobgpapi.DeletePolicyResponse, error) {
+	return nil, nil
+}
+func (f *fakeGoBgpClient) ListPolicy(_ context.Context, _ *gobgpapi.ListPolicyRequest, _ ...grpc.CallOption) (grpc.ServerStreamingClient[gobgpapi.ListPolicyResponse], error) {
+	return nil, nil
+}
+func (f *fakeGoBgpClient) SetPolicies(_ context.Context, _ *gobgpapi.SetPoliciesRequest, _ ...grpc.CallOption) (*gobgpapi.SetPoliciesResponse, error) {
+	return nil, nil
+}
+func (f *fakeGoBgpClient) AddDefinedSet(_ context.Context, _ *gobgpapi.AddDefinedSetRequest, _ ...grpc.CallOption) (*gobgpapi.AddDefinedSetResponse, error) {
+	return nil, nil
+}
+func (f *fakeGoBgpClient) DeleteDefinedSet(_ context.Context, _ *gobgpapi.DeleteDefinedSetRequest, _ ...grpc.CallOption) (*gobgpapi.DeleteDefinedSetResponse, error) {
+	return nil, nil
+}
+func (f *fakeGoBgpClient) ListDefinedSet(_ context.Context, _ *gobgpapi.ListDefinedSetRequest, _ ...grpc.CallOption) (grpc.ServerStreamingClient[gobgpapi.ListDefinedSetResponse], error) {
+	return nil, nil
+}
+func (f *fakeGoBgpClient) AddStatement(_ context.Context, _ *gobgpapi.AddStatementRequest, _ ...grpc.CallOption) (*gobgpapi.AddStatementResponse, error) {
+	return nil, nil
+}
+func (f *fakeGoBgpClient) DeleteStatement(_ context.Context, _ *gobgpapi.DeleteStatementRequest, _ ...grpc.CallOption) (*gobgpapi.DeleteStatementResponse, error) {
+	return nil, nil
+}
+func (f *fakeGoBgpClient) ListStatement(_ context.Context, _ *gobgpapi.ListStatementRequest, _ ...grpc.CallOption) (grpc.ServerStreamingClient[gobgpapi.ListStatementResponse], error) {
+	return nil, nil
+}
+func (f *fakeGoBgpClient) AddPolicyAssignment(_ context.Context, _ *gobgpapi.AddPolicyAssignmentRequest, _ ...grpc.CallOption) (*gobgpapi.AddPolicyAssignmentResponse, error) {
+	return nil, nil
+}
+func (f *fakeGoBgpClient) DeletePolicyAssignment(_ context.Context, _ *gobgpapi.DeletePolicyAssignmentRequest, _ ...grpc.CallOption) (*gobgpapi.DeletePolicyAssignmentResponse, error) {
+	return nil, nil
+}
+func (f *fakeGoBgpClient) ListPolicyAssignment(_ context.Context, _ *gobgpapi.ListPolicyAssignmentRequest, _ ...grpc.CallOption) (grpc.ServerStreamingClient[gobgpapi.ListPolicyAssignmentResponse], error) {
+	return nil, nil
+}
+func (f *fakeGoBgpClient) SetPolicyAssignment(_ context.Context, _ *gobgpapi.SetPolicyAssignmentRequest, _ ...grpc.CallOption) (*gobgpapi.SetPolicyAssignmentResponse, error) {
+	return nil, nil
+}
+func (f *fakeGoBgpClient) AddRpki(_ context.Context, _ *gobgpapi.AddRpkiRequest, _ ...grpc.CallOption) (*gobgpapi.AddRpkiResponse, error) {
+	return nil, nil
+}
+func (f *fakeGoBgpClient) DeleteRpki(_ context.Context, _ *gobgpapi.DeleteRpkiRequest, _ ...grpc.CallOption) (*gobgpapi.DeleteRpkiResponse, error) {
+	return nil, nil
+}
+func (f *fakeGoBgpClient) ListRpki(_ context.Context, _ *gobgpapi.ListRpkiRequest, _ ...grpc.CallOption) (grpc.ServerStreamingClient[gobgpapi.ListRpkiResponse], error) {
+	return nil, nil
+}
+func (f *fakeGoBgpClient) EnableRpki(_ context.Context, _ *gobgpapi.EnableRpkiRequest, _ ...grpc.CallOption) (*gobgpapi.EnableRpkiResponse, error) {
+	return nil, nil
+}
+func (f *fakeGoBgpClient) DisableRpki(_ context.Context, _ *gobgpapi.DisableRpkiRequest, _ ...grpc.CallOption) (*gobgpapi.DisableRpkiResponse, error) {
+	return nil, nil
+}
+func (f *fakeGoBgpClient) ResetRpki(_ context.Context, _ *gobgpapi.ResetRpkiRequest, _ ...grpc.CallOption) (*gobgpapi.ResetRpkiResponse, error) {
+	return nil, nil
+}
+func (f *fakeGoBgpClient) ListRpkiTable(_ context.Context, _ *gobgpapi.ListRpkiTableRequest, _ ...grpc.CallOption) (grpc.ServerStreamingClient[gobgpapi.ListRpkiTableResponse], error) {
+	return nil, nil
+}
+func (f *fakeGoBgpClient) EnableZebra(_ context.Context, _ *gobgpapi.EnableZebraRequest, _ ...grpc.CallOption) (*gobgpapi.EnableZebraResponse, error) {
+	return nil, nil
+}
+func (f *fakeGoBgpClient) EnableMrt(_ context.Context, _ *gobgpapi.EnableMrtRequest, _ ...grpc.CallOption) (*gobgpapi.EnableMrtResponse, error) {
+	return nil, nil
+}
+func (f *fakeGoBgpClient) DisableMrt(_ context.Context, _ *gobgpapi.DisableMrtRequest, _ ...grpc.CallOption) (*gobgpapi.DisableMrtResponse, error) {
+	return nil, nil
+}
+func (f *fakeGoBgpClient) AddBmp(_ context.Context, _ *gobgpapi.AddBmpRequest, _ ...grpc.CallOption) (*gobgpapi.AddBmpResponse, error) {
+	return nil, nil
+}
+func (f *fakeGoBgpClient) DeleteBmp(_ context.Context, _ *gobgpapi.DeleteBmpRequest, _ ...grpc.CallOption) (*gobgpapi.DeleteBmpResponse, error) {
+	return nil, nil
+}
+func (f *fakeGoBgpClient) ListBmp(_ context.Context, _ *gobgpapi.ListBmpRequest, _ ...grpc.CallOption) (grpc.ServerStreamingClient[gobgpapi.ListBmpResponse], error) {
+	return nil, nil
+}
+func (f *fakeGoBgpClient) SetLogLevel(_ context.Context, _ *gobgpapi.SetLogLevelRequest, _ ...grpc.CallOption) (*gobgpapi.SetLogLevelResponse, error) {
+	return nil, nil
+}
 
 func TestAfiSafiFromStrings(t *testing.T) {
 	tests := []struct {
@@ -200,4 +380,101 @@ func TestAddPathInvalidCIDR(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestConfigureSpeaker exercises the StopBgp/StartBgp guard logic, including the
+// GoBGP v4 behaviour where an uninitialised daemon returns Asn=0 rather than
+// a NotFound error.
+func TestConfigureSpeaker(t *testing.T) {
+	spec := provider.SpeakerSpec{
+		ASNumber:   64512,
+		RouterID:   "10.0.0.1",
+		ListenPort: 1790,
+	}
+
+	t.Run("uninitialised (Asn=0): skips StopBgp, calls StartBgp", func(t *testing.T) {
+		fake := &fakeGoBgpClient{
+			getBgpFn: func(_ context.Context, _ *gobgpapi.GetBgpRequest, _ ...grpc.CallOption) (*gobgpapi.GetBgpResponse, error) {
+				return &gobgpapi.GetBgpResponse{Global: &gobgpapi.Global{Asn: 0}}, nil
+			},
+		}
+		p := &Provider{client: fake}
+
+		restarted, err := p.ConfigureSpeaker(context.Background(), spec)
+		if err != nil {
+			t.Fatalf("ConfigureSpeaker: unexpected error: %v", err)
+		}
+		if !restarted {
+			t.Error("restarted = false, want true")
+		}
+		if fake.stopBgpN != 0 {
+			t.Errorf("StopBgp called %d time(s), want 0 — must not stop an uninitialised daemon", fake.stopBgpN)
+		}
+		if fake.startBgpReq == nil {
+			t.Fatal("StartBgp not called")
+		}
+		g := fake.startBgpReq.Global
+		if g.Asn != 64512 {
+			t.Errorf("StartBgp Global.Asn = %d, want 64512", g.Asn)
+		}
+		if g.RouterId != "10.0.0.1" {
+			t.Errorf("StartBgp Global.RouterId = %q, want %q", g.RouterId, "10.0.0.1")
+		}
+		if g.ListenPort != 1790 {
+			t.Errorf("StartBgp Global.ListenPort = %d, want 1790", g.ListenPort)
+		}
+	})
+
+	t.Run("running with matching config: no restart", func(t *testing.T) {
+		fake := &fakeGoBgpClient{
+			getBgpFn: func(_ context.Context, _ *gobgpapi.GetBgpRequest, _ ...grpc.CallOption) (*gobgpapi.GetBgpResponse, error) {
+				return &gobgpapi.GetBgpResponse{Global: &gobgpapi.Global{
+					Asn: 64512, RouterId: "10.0.0.1", ListenPort: 1790,
+				}}, nil
+			},
+		}
+		p := &Provider{client: fake}
+
+		restarted, err := p.ConfigureSpeaker(context.Background(), spec)
+		if err != nil {
+			t.Fatalf("ConfigureSpeaker: unexpected error: %v", err)
+		}
+		if restarted {
+			t.Error("restarted = true, want false (config unchanged)")
+		}
+		if fake.stopBgpN != 0 {
+			t.Errorf("StopBgp called %d time(s), want 0", fake.stopBgpN)
+		}
+		if fake.startBgpReq != nil {
+			t.Error("StartBgp called, want not called")
+		}
+	})
+
+	t.Run("running with mismatched ASN: stops then restarts", func(t *testing.T) {
+		fake := &fakeGoBgpClient{
+			getBgpFn: func(_ context.Context, _ *gobgpapi.GetBgpRequest, _ ...grpc.CallOption) (*gobgpapi.GetBgpResponse, error) {
+				return &gobgpapi.GetBgpResponse{Global: &gobgpapi.Global{
+					Asn: 65000, RouterId: "10.0.0.1", ListenPort: 1790,
+				}}, nil
+			},
+		}
+		p := &Provider{client: fake}
+
+		restarted, err := p.ConfigureSpeaker(context.Background(), spec)
+		if err != nil {
+			t.Fatalf("ConfigureSpeaker: unexpected error: %v", err)
+		}
+		if !restarted {
+			t.Error("restarted = false, want true")
+		}
+		if fake.stopBgpN != 1 {
+			t.Errorf("StopBgp called %d time(s), want 1", fake.stopBgpN)
+		}
+		if fake.startBgpReq == nil {
+			t.Fatal("StartBgp not called")
+		}
+		if fake.startBgpReq.Global.Asn != 64512 {
+			t.Errorf("StartBgp Global.Asn = %d, want 64512", fake.startBgpReq.Global.Asn)
+		}
+	})
 }


### PR DESCRIPTION
## Summary

- GoBGP v4 returns `Global.Asn=0` (not `NotFound`) when the BGP engine has not been started yet. The previous `StopBgp` guard (`resp != nil && resp.Global != nil`) was true in this case, causing `StopBgp` to be called on an uninitialised server, which terminates the gobgpd process entirely. The subsequent `StartBgp` then failed with "server stopped".
- Extend the guard to `resp.Global.Asn != 0` and update the `needsRestart` check to treat `Asn==0` as "not yet started" — skip `StopBgp`, go straight to `StartBgp`.
- Add `TestConfigureSpeaker` with subtests covering the uninitialised (Asn=0), no-change, and config-mismatch paths using a `fakeGoBgpClient` that implements the full `GoBgpServiceClient` interface.

## Test plan

- [ ] `go test ./internal/provider/gobgp/...` passes (all three subtests green)
- [ ] Verify in a live lab: operator connecting to a freshly started gobgpd no longer causes the daemon to exit

🤖 Generated with [Claude Code](https://claude.com/claude-code)