### PR TITLE
feat(bgp): add L2VPN/EVPN address family support

### DIFF
--- a/api/bgp/v1alpha1/shared_types.go
+++ b/api/bgp/v1alpha1/shared_types.go
@@ -3,23 +3,25 @@ package v1alpha1
 import metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 const (
-	AFIIPv4 = "IPv4"
-	AFIIPv6 = "IPv6"
+	AFIIPv4  = "IPv4"
+	AFIIPv6  = "IPv6"
+	AFIL2VPN = "L2VPN"
 
 	SAFIUnicast    = "Unicast"
 	SAFIVPNUnicast = "VPNUnicast"
+	SAFIEVPN       = "EVPN"
 )
 
 // AddressFamily represents a BGP address family (AFI/SAFI pair).
 type AddressFamily struct {
 	// AFI is the Address Family Identifier.
 	//
-	// +kubebuilder:validation:Enum=IPv4;IPv6
+	// +kubebuilder:validation:Enum=IPv4;IPv6;L2VPN
 	AFI string `json:"afi"`
 
 	// SAFI is the Subsequent Address Family Identifier.
 	//
-	// +kubebuilder:validation:Enum=Unicast;VPNUnicast
+	// +kubebuilder:validation:Enum=Unicast;VPNUnicast;EVPN
 	SAFI string `json:"safi"`
 }
 

--- a/api/providers/v1alpha1/provider_types.go
+++ b/api/providers/v1alpha1/provider_types.go
@@ -107,12 +107,12 @@ type ProviderCapabilities struct {
 type AddressFamilyCapability struct {
 	// AFI is the Address Family Identifier.
 	//
-	// +kubebuilder:validation:Enum=IPv4;IPv6
+	// +kubebuilder:validation:Enum=IPv4;IPv6;L2VPN
 	AFI string `json:"afi"`
 
 	// SAFI is the Subsequent Address Family Identifier.
 	//
-	// +kubebuilder:validation:Enum=Unicast;VPNUnicast
+	// +kubebuilder:validation:Enum=Unicast;VPNUnicast;EVPN
 	SAFI string `json:"safi"`
 }
 

--- a/config/crd/bgp.miloapis.com_bgpadvertisements.yaml
+++ b/config/crd/bgp.miloapis.com_bgpadvertisements.yaml
@@ -271,6 +271,7 @@ spec:
                                 enum:
                                 - IPv4
                                 - IPv6
+                                - L2VPN
                                 type: string
                               safi:
                                 description: SAFI is the Subsequent Address Family
@@ -278,6 +279,7 @@ spec:
                                 enum:
                                 - Unicast
                                 - VPNUnicast
+                                - EVPN
                                 type: string
                             required:
                             - afi

--- a/config/crd/bgp.miloapis.com_bgpinstances.yaml
+++ b/config/crd/bgp.miloapis.com_bgpinstances.yaml
@@ -61,12 +61,14 @@ spec:
                       enum:
                       - IPv4
                       - IPv6
+                      - L2VPN
                       type: string
                     safi:
                       description: SAFI is the Subsequent Address Family Identifier.
                       enum:
                       - Unicast
                       - VPNUnicast
+                      - EVPN
                       type: string
                   required:
                   - afi
@@ -356,6 +358,7 @@ spec:
                                 enum:
                                 - IPv4
                                 - IPv6
+                                - L2VPN
                                 type: string
                               safi:
                                 description: SAFI is the Subsequent Address Family
@@ -363,6 +366,7 @@ spec:
                                 enum:
                                 - Unicast
                                 - VPNUnicast
+                                - EVPN
                                 type: string
                             required:
                             - afi

--- a/config/crd/bgp.miloapis.com_bgppeers.yaml
+++ b/config/crd/bgp.miloapis.com_bgppeers.yaml
@@ -71,12 +71,14 @@ spec:
                       enum:
                       - IPv4
                       - IPv6
+                      - L2VPN
                       type: string
                     safi:
                       description: SAFI is the Subsequent Address Family Identifier.
                       enum:
                       - Unicast
                       - VPNUnicast
+                      - EVPN
                       type: string
                   required:
                   - afi
@@ -387,6 +389,7 @@ spec:
                                 enum:
                                 - IPv4
                                 - IPv6
+                                - L2VPN
                                 type: string
                               safi:
                                 description: SAFI is the Subsequent Address Family
@@ -394,6 +397,7 @@ spec:
                                 enum:
                                 - Unicast
                                 - VPNUnicast
+                                - EVPN
                                 type: string
                             required:
                             - afi

--- a/config/crd/bgp.miloapis.com_bgproutepolicies.yaml
+++ b/config/crd/bgp.miloapis.com_bgproutepolicies.yaml
@@ -364,6 +364,7 @@ spec:
                                 enum:
                                 - IPv4
                                 - IPv6
+                                - L2VPN
                                 type: string
                               safi:
                                 description: SAFI is the Subsequent Address Family
@@ -371,6 +372,7 @@ spec:
                                 enum:
                                 - Unicast
                                 - VPNUnicast
+                                - EVPN
                                 type: string
                             required:
                             - afi

--- a/config/crd/bgp.miloapis.com_bgpsessions.yaml
+++ b/config/crd/bgp.miloapis.com_bgpsessions.yaml
@@ -61,12 +61,14 @@ spec:
                       enum:
                       - IPv4
                       - IPv6
+                      - L2VPN
                       type: string
                     safi:
                       description: SAFI is the Subsequent Address Family Identifier.
                       enum:
                       - Unicast
                       - VPNUnicast
+                      - EVPN
                       type: string
                   required:
                   - afi

--- a/config/crd/providers.bgp.miloapis.com_bgpproviders.yaml
+++ b/config/crd/providers.bgp.miloapis.com_bgpproviders.yaml
@@ -112,12 +112,14 @@ spec:
                           enum:
                           - IPv4
                           - IPv6
+                          - L2VPN
                           type: string
                         safi:
                           description: SAFI is the Subsequent Address Family Identifier.
                           enum:
                           - Unicast
                           - VPNUnicast
+                          - EVPN
                           type: string
                       required:
                       - afi

--- a/internal/controller/peer_reconciler_test.go
+++ b/internal/controller/peer_reconciler_test.go
@@ -1,0 +1,171 @@
+package controller
+
+import (
+	"context"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	bgpv1alpha1 "go.miloapis.com/cosmos/api/bgp/v1alpha1"
+	providersv1alpha1 "go.miloapis.com/cosmos/api/providers/v1alpha1"
+	"go.miloapis.com/cosmos/internal/provider"
+)
+
+// peerRecordingProvider records the most recent AddOrUpdatePeer call for inspection.
+type peerRecordingProvider struct {
+	lastPeerSpec provider.PeerSpec
+}
+
+func (p *peerRecordingProvider) ConfigureSpeaker(_ context.Context, _ provider.SpeakerSpec) (bool, error) {
+	return false, nil
+}
+func (p *peerRecordingProvider) AddOrUpdatePeer(_ context.Context, spec provider.PeerSpec) error {
+	p.lastPeerSpec = spec
+	return nil
+}
+func (p *peerRecordingProvider) DeletePeer(_ context.Context, _ string) error { return nil }
+func (p *peerRecordingProvider) AddOrUpdateAdvertisement(_ context.Context, _ provider.AdvertisementSpec) error {
+	return nil
+}
+func (p *peerRecordingProvider) DeleteAdvertisement(_ context.Context, _ string) error            { return nil }
+func (p *peerRecordingProvider) AddOrUpdatePolicy(_ context.Context, _ provider.PolicySpec) error { return nil }
+func (p *peerRecordingProvider) DeletePolicy(_ context.Context, _ string) error                   { return nil }
+func (p *peerRecordingProvider) Ready(_ context.Context) error                                    { return nil }
+func (p *peerRecordingProvider) Capabilities(_ context.Context) (provider.CapabilitySet, error) {
+	return provider.CapabilitySet{}, nil
+}
+
+// TestPeerReconcilerEVPNAddressFamily is an end-to-end controller test that
+// verifies L2VPN/EVPN address families flow from BGPPeer.spec through
+// reconcileForProvider to the provider's AddOrUpdatePeer call.
+func TestPeerReconcilerEVPNAddressFamily(t *testing.T) {
+	instance := &bgpv1alpha1.BGPInstance{
+		ObjectMeta: metav1.ObjectMeta{Name: "overlay"},
+		Spec: bgpv1alpha1.BGPInstanceSpec{
+			ASNumber:       65001,
+			RouterIDSource: "Manual",
+			RouterID:       "10.0.0.1",
+			ProviderSelector: metav1.LabelSelector{
+				MatchLabels: map[string]string{"role": "vtep"},
+			},
+			AddressFamilies: []bgpv1alpha1.AddressFamily{
+				{AFI: bgpv1alpha1.AFIL2VPN, SAFI: bgpv1alpha1.SAFIEVPN},
+			},
+		},
+	}
+	bp := &providersv1alpha1.BGPProvider{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   "node-a",
+			Labels: map[string]string{"role": "vtep"},
+		},
+		Spec: providersv1alpha1.BGPProviderSpec{Type: "FRR"},
+	}
+	bgpPeer := &bgpv1alpha1.BGPPeer{
+		ObjectMeta: metav1.ObjectMeta{Name: "evpn-peer"},
+		Spec: bgpv1alpha1.BGPPeerSpec{
+			InstanceRef: "overlay",
+			ProviderRef: "node-a",
+			Address:     "2001:db8::2",
+			ASNumber:    65001,
+			AddressFamilies: []bgpv1alpha1.AddressFamily{
+				{AFI: bgpv1alpha1.AFIL2VPN, SAFI: bgpv1alpha1.SAFIEVPN},
+			},
+		},
+	}
+
+	recording := &peerRecordingProvider{}
+	reg := provider.NewRegistry()
+	reg.Set("node-a", recording)
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(instance, bp, bgpPeer).
+		WithStatusSubresource(bgpPeer).
+		Build()
+
+	r := &PeerReconciler{
+		Client:   fakeClient,
+		Scheme:   scheme,
+		Registry: reg,
+	}
+
+	if err := r.reconcileForProvider(context.Background(), bgpPeer, instance, *bp); err != nil {
+		t.Fatalf("reconcileForProvider: %v", err)
+	}
+
+	fams := recording.lastPeerSpec.Families
+	if len(fams) != 1 {
+		t.Fatalf("Families len = %d, want 1", len(fams))
+	}
+	if fams[0].AFI != bgpv1alpha1.AFIL2VPN {
+		t.Errorf("Families[0].AFI = %q, want %q", fams[0].AFI, bgpv1alpha1.AFIL2VPN)
+	}
+	if fams[0].SAFI != bgpv1alpha1.SAFIEVPN {
+		t.Errorf("Families[0].SAFI = %q, want %q", fams[0].SAFI, bgpv1alpha1.SAFIEVPN)
+	}
+}
+
+// TestPeerReconcilerEVPNInheritedFromInstance verifies that when BGPPeer has no
+// explicit address families, it inherits L2VPN/EVPN from the BGPInstance.
+func TestPeerReconcilerEVPNInheritedFromInstance(t *testing.T) {
+	instance := &bgpv1alpha1.BGPInstance{
+		ObjectMeta: metav1.ObjectMeta{Name: "overlay"},
+		Spec: bgpv1alpha1.BGPInstanceSpec{
+			ASNumber:       65001,
+			RouterIDSource: "Manual",
+			RouterID:       "10.0.0.1",
+			ProviderSelector: metav1.LabelSelector{
+				MatchLabels: map[string]string{"role": "vtep"},
+			},
+			AddressFamilies: []bgpv1alpha1.AddressFamily{
+				{AFI: bgpv1alpha1.AFIL2VPN, SAFI: bgpv1alpha1.SAFIEVPN},
+			},
+		},
+	}
+	bp := &providersv1alpha1.BGPProvider{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   "node-a",
+			Labels: map[string]string{"role": "vtep"},
+		},
+		Spec: providersv1alpha1.BGPProviderSpec{Type: "FRR"},
+	}
+	// BGPPeer carries no addressFamilies — must inherit from instance.
+	bgpPeer := &bgpv1alpha1.BGPPeer{
+		ObjectMeta: metav1.ObjectMeta{Name: "evpn-peer-inherit"},
+		Spec: bgpv1alpha1.BGPPeerSpec{
+			InstanceRef: "overlay",
+			ProviderRef: "node-a",
+			Address:     "2001:db8::2",
+			ASNumber:    65001,
+		},
+	}
+
+	recording := &peerRecordingProvider{}
+	reg := provider.NewRegistry()
+	reg.Set("node-a", recording)
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(instance, bp, bgpPeer).
+		WithStatusSubresource(bgpPeer).
+		Build()
+
+	r := &PeerReconciler{
+		Client:   fakeClient,
+		Scheme:   scheme,
+		Registry: reg,
+	}
+
+	if err := r.reconcileForProvider(context.Background(), bgpPeer, instance, *bp); err != nil {
+		t.Fatalf("reconcileForProvider: %v", err)
+	}
+
+	fams := recording.lastPeerSpec.Families
+	if len(fams) != 1 {
+		t.Fatalf("Families len = %d, want 1 (inherited from instance)", len(fams))
+	}
+	if fams[0].AFI != bgpv1alpha1.AFIL2VPN || fams[0].SAFI != bgpv1alpha1.SAFIEVPN {
+		t.Errorf("Families[0] = {%s,%s}, want {L2VPN,EVPN}", fams[0].AFI, fams[0].SAFI)
+	}
+}

--- a/internal/controller/session_reconciler_test.go
+++ b/internal/controller/session_reconciler_test.go
@@ -1,0 +1,137 @@
+package controller
+
+import (
+	"context"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	bgpv1alpha1 "go.miloapis.com/cosmos/api/bgp/v1alpha1"
+	providersv1alpha1 "go.miloapis.com/cosmos/api/providers/v1alpha1"
+)
+
+// TestBuildBGPPeerPreservesEVPN verifies that buildBGPPeer passes the L2VPN/EVPN
+// address family from the BGPSession spec through to the generated BGPPeer unchanged.
+func TestBuildBGPPeerPreservesEVPN(t *testing.T) {
+	r := &SessionReconciler{}
+
+	session := &bgpv1alpha1.BGPSession{
+		ObjectMeta: metav1.ObjectMeta{Name: "evpn-session"},
+		Spec: bgpv1alpha1.BGPSessionSpec{
+			FromInstanceRef: "overlay",
+			AddressFamilies: []bgpv1alpha1.AddressFamily{
+				{AFI: bgpv1alpha1.AFIL2VPN, SAFI: bgpv1alpha1.SAFIEVPN},
+			},
+		},
+	}
+	bp := &providersv1alpha1.BGPProvider{
+		ObjectMeta: metav1.ObjectMeta{Name: "node-a"},
+	}
+	toPeer := bgpv1alpha1.SessionPeer{
+		Address:  "2001:db8::1",
+		ASNumber: 65001,
+	}
+
+	peer := r.buildBGPPeer(session, bp, toPeer)
+
+	if len(peer.Spec.AddressFamilies) != 1 {
+		t.Fatalf("AddressFamilies len = %d, want 1", len(peer.Spec.AddressFamilies))
+	}
+	af := peer.Spec.AddressFamilies[0]
+	if af.AFI != bgpv1alpha1.AFIL2VPN {
+		t.Errorf("AFI = %q, want %q", af.AFI, bgpv1alpha1.AFIL2VPN)
+	}
+	if af.SAFI != bgpv1alpha1.SAFIEVPN {
+		t.Errorf("SAFI = %q, want %q", af.SAFI, bgpv1alpha1.SAFIEVPN)
+	}
+}
+
+// TestBuildBGPPeerPreservesMultipleFamilies verifies that a mixed address family
+// list (VPNUnicast + EVPN) is preserved in full on the generated BGPPeer.
+func TestBuildBGPPeerPreservesMultipleFamilies(t *testing.T) {
+	r := &SessionReconciler{}
+
+	session := &bgpv1alpha1.BGPSession{
+		ObjectMeta: metav1.ObjectMeta{Name: "mixed-session"},
+		Spec: bgpv1alpha1.BGPSessionSpec{
+			FromInstanceRef: "overlay",
+			AddressFamilies: []bgpv1alpha1.AddressFamily{
+				{AFI: bgpv1alpha1.AFIIPv6, SAFI: bgpv1alpha1.SAFIVPNUnicast},
+				{AFI: bgpv1alpha1.AFIL2VPN, SAFI: bgpv1alpha1.SAFIEVPN},
+			},
+		},
+	}
+	bp := &providersv1alpha1.BGPProvider{ObjectMeta: metav1.ObjectMeta{Name: "node-a"}}
+	toPeer := bgpv1alpha1.SessionPeer{Address: "2001:db8::1", ASNumber: 65001}
+
+	peer := r.buildBGPPeer(session, bp, toPeer)
+
+	if len(peer.Spec.AddressFamilies) != 2 {
+		t.Fatalf("AddressFamilies len = %d, want 2", len(peer.Spec.AddressFamilies))
+	}
+	if peer.Spec.AddressFamilies[1].AFI != bgpv1alpha1.AFIL2VPN ||
+		peer.Spec.AddressFamilies[1].SAFI != bgpv1alpha1.SAFIEVPN {
+		t.Errorf("AddressFamilies[1] = {%s,%s}, want {L2VPN,EVPN}",
+			peer.Spec.AddressFamilies[1].AFI, peer.Spec.AddressFamilies[1].SAFI)
+	}
+}
+
+// TestReconcilePopInfraGeneratesEVPNPeer is an end-to-end controller test that
+// runs reconcilePopInfra with an EVPN BGPSession and verifies that the generated
+// BGPPeer carries the L2VPN/EVPN address family.
+func TestReconcilePopInfraGeneratesEVPNPeer(t *testing.T) {
+	session := &bgpv1alpha1.BGPSession{
+		ObjectMeta: metav1.ObjectMeta{Name: "evpn-overlay"},
+		Spec: bgpv1alpha1.BGPSessionSpec{
+			FromProviderSelector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{"role": "vtep"},
+			},
+			FromInstanceRef: "overlay",
+			ToPeers: []bgpv1alpha1.SessionPeer{
+				{Address: "2001:db8::2", ASNumber: 65001, InstanceRef: "overlay"},
+			},
+			AddressFamilies: []bgpv1alpha1.AddressFamily{
+				{AFI: bgpv1alpha1.AFIL2VPN, SAFI: bgpv1alpha1.SAFIEVPN},
+			},
+		},
+	}
+	bp := &providersv1alpha1.BGPProvider{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   "node-a",
+			Labels: map[string]string{"role": "vtep"},
+		},
+		Spec: providersv1alpha1.BGPProviderSpec{Type: "FRR"},
+	}
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(session, bp).
+		WithStatusSubresource(session).
+		Build()
+
+	r := &SessionReconciler{
+		Client: fakeClient,
+		Scheme: scheme,
+	}
+
+	if _, err := r.reconcilePopInfra(context.Background(), session); err != nil {
+		t.Fatalf("reconcilePopInfra: %v", err)
+	}
+
+	var peerList bgpv1alpha1.BGPPeerList
+	if err := fakeClient.List(context.Background(), &peerList); err != nil {
+		t.Fatalf("list BGPPeers: %v", err)
+	}
+	if len(peerList.Items) != 1 {
+		t.Fatalf("BGPPeer count = %d, want 1", len(peerList.Items))
+	}
+	peer := peerList.Items[0]
+	if len(peer.Spec.AddressFamilies) != 1 {
+		t.Fatalf("AddressFamilies len = %d, want 1", len(peer.Spec.AddressFamilies))
+	}
+	af := peer.Spec.AddressFamilies[0]
+	if af.AFI != bgpv1alpha1.AFIL2VPN || af.SAFI != bgpv1alpha1.SAFIEVPN {
+		t.Errorf("AddressFamilies[0] = {%s,%s}, want {L2VPN,EVPN}", af.AFI, af.SAFI)
+	}
+}

--- a/internal/provider/frr/provider.go
+++ b/internal/provider/frr/provider.go
@@ -42,6 +42,7 @@ var FRRCapabilities = provider.CapabilitySet{
 		{AFI: "IPv6", SAFI: "Unicast"},
 		{AFI: "IPv4", SAFI: "VPNUnicast"},
 		{AFI: "IPv6", SAFI: "VPNUnicast"},
+		{AFI: "L2VPN", SAFI: "EVPN"},
 	},
 	RouteReflection: true,
 	BFD:             false,
@@ -461,6 +462,8 @@ func frrAFI(afi string) string {
 	switch afi {
 	case "IPv4":
 		return "ipv4"
+	case "L2VPN":
+		return "l2vpn"
 	default: // "IPv6"
 		return "ipv6"
 	}
@@ -471,6 +474,8 @@ func frrSAFI(safi string) string {
 	switch safi {
 	case "VPNUnicast":
 		return "vpn"
+	case "EVPN":
+		return "evpn"
 	default: // "Unicast"
 		return "unicast"
 	}

--- a/internal/provider/frr/provider_test.go
+++ b/internal/provider/frr/provider_test.go
@@ -1,0 +1,54 @@
+package frr
+
+import (
+	"testing"
+)
+
+func TestFrrAFI(t *testing.T) {
+	tests := []struct {
+		afi  string
+		want string
+	}{
+		{"IPv4", "ipv4"},
+		{"IPv6", "ipv6"},
+		{"L2VPN", "l2vpn"},
+		{"unknown", "ipv6"}, // default branch
+	}
+	for _, tc := range tests {
+		t.Run(tc.afi, func(t *testing.T) {
+			got := frrAFI(tc.afi)
+			if got != tc.want {
+				t.Errorf("frrAFI(%q) = %q, want %q", tc.afi, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestFrrSAFI(t *testing.T) {
+	tests := []struct {
+		safi string
+		want string
+	}{
+		{"Unicast", "unicast"},
+		{"VPNUnicast", "vpn"},
+		{"EVPN", "evpn"},
+		{"unknown", "unicast"}, // default branch
+	}
+	for _, tc := range tests {
+		t.Run(tc.safi, func(t *testing.T) {
+			got := frrSAFI(tc.safi)
+			if got != tc.want {
+				t.Errorf("frrSAFI(%q) = %q, want %q", tc.safi, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestFRRCapabilitiesContainEVPN(t *testing.T) {
+	for _, af := range FRRCapabilities.AddressFamilies {
+		if af.AFI == "L2VPN" && af.SAFI == "EVPN" {
+			return
+		}
+	}
+	t.Error("FRRCapabilities.AddressFamilies does not contain {L2VPN, EVPN}")
+}

--- a/internal/provider/gobgp/provider.go
+++ b/internal/provider/gobgp/provider.go
@@ -38,6 +38,7 @@ var GoBGPCapabilities = provider.CapabilitySet{
 	AddressFamilies: []provider.AddressFamily{
 		{AFI: "IPv4", SAFI: "VPNUnicast"},
 		{AFI: "IPv6", SAFI: "VPNUnicast"},
+		{AFI: "L2VPN", SAFI: "EVPN"},
 	},
 	RouteReflection: false,
 	BFD:             false,
@@ -351,6 +352,8 @@ func afiSafiFromStrings(afi, safi string) (gobgpapi.Family_Afi, gobgpapi.Family_
 	switch afi {
 	case "IPv4":
 		a = gobgpapi.Family_AFI_IP
+	case "L2VPN":
+		a = gobgpapi.Family_AFI_L2VPN
 	default: // "IPv6"
 		a = gobgpapi.Family_AFI_IP6
 	}
@@ -359,6 +362,8 @@ func afiSafiFromStrings(afi, safi string) (gobgpapi.Family_Afi, gobgpapi.Family_
 	switch safi {
 	case "VPNUnicast":
 		s = gobgpapi.Family_SAFI_MPLS_VPN
+	case "EVPN":
+		s = gobgpapi.Family_SAFI_EVPN
 	default: // "Unicast"
 		s = gobgpapi.Family_SAFI_UNICAST
 	}

--- a/internal/provider/gobgp/provider_test.go
+++ b/internal/provider/gobgp/provider_test.go
@@ -200,6 +200,7 @@ func TestAfiSafiFromStrings(t *testing.T) {
 		{"IPv6", "Unicast", gobgpapi.Family_AFI_IP6, gobgpapi.Family_SAFI_UNICAST},
 		{"IPv4", "VPNUnicast", gobgpapi.Family_AFI_IP, gobgpapi.Family_SAFI_MPLS_VPN},
 		{"IPv6", "VPNUnicast", gobgpapi.Family_AFI_IP6, gobgpapi.Family_SAFI_MPLS_VPN},
+		{"L2VPN", "EVPN", gobgpapi.Family_AFI_L2VPN, gobgpapi.Family_SAFI_EVPN},
 		// Unknown AFI falls back to IPv6 (default branch).
 		{"unknown", "Unicast", gobgpapi.Family_AFI_IP6, gobgpapi.Family_SAFI_UNICAST},
 		// Unknown SAFI falls back to Unicast (default branch).
@@ -272,6 +273,35 @@ func TestBuildAfiSafis(t *testing.T) {
 			}
 		}
 	})
+
+	t.Run("L2VPN EVPN family", func(t *testing.T) {
+		families := []provider.AddressFamily{
+			{AFI: "L2VPN", SAFI: "EVPN"},
+		}
+		result := buildAfiSafis(families)
+		if len(result) != 1 {
+			t.Fatalf("len = %d, want 1", len(result))
+		}
+		cfg := result[0].Config
+		if cfg.Family.Afi != gobgpapi.Family_AFI_L2VPN {
+			t.Errorf("AFI = %v, want AFI_L2VPN", cfg.Family.Afi)
+		}
+		if cfg.Family.Safi != gobgpapi.Family_SAFI_EVPN {
+			t.Errorf("SAFI = %v, want SAFI_EVPN", cfg.Family.Safi)
+		}
+		if !cfg.Enabled {
+			t.Error("Enabled = false, want true")
+		}
+	})
+}
+
+func TestGoBGPCapabilitiesContainEVPN(t *testing.T) {
+	for _, af := range GoBGPCapabilities.AddressFamilies {
+		if af.AFI == "L2VPN" && af.SAFI == "EVPN" {
+			return
+		}
+	}
+	t.Error("GoBGPCapabilities.AddressFamilies does not contain {L2VPN, EVPN}")
 }
 
 func TestBuildPeer(t *testing.T) {


### PR DESCRIPTION
## Summary

- Adds `AFIL2VPN = "L2VPN"` and `SAFIEVPN = "EVPN"` constants to `api/bgp/v1alpha1/shared_types.go` and extends the `AddressFamily` kubebuilder enum markers to include them
- Wires `L2VPN → l2vpn` and `EVPN → evpn` in the FRR vtysh helper functions and adds `{L2VPN, EVPN}` to `FRRCapabilities`
- Maps `L2VPN → Family_AFI_L2VPN` and `EVPN → Family_SAFI_EVPN` in the GoBGP provider and adds `{L2VPN, EVPN}` to `GoBGPCapabilities`

## Test plan

- [ ] `TestFrrAFI` / `TestFrrSAFI` — FRR keyword mapping for all AFI/SAFI values including L2VPN/EVPN
- [ ] `TestFRRCapabilitiesContainEVPN` — static capability set includes L2VPN/EVPN
- [ ] `TestAfiSafiFromStrings` (L2VPN/EVPN row) — GoBGP constant mapping
- [ ] `TestBuildAfiSafis` (L2VPN EVPN family sub-test) — `buildAfiSafis` output
- [ ] `TestGoBGPCapabilitiesContainEVPN` — static capability set includes L2VPN/EVPN
- [ ] `TestBuildBGPPeerPreservesEVPN` / `TestBuildBGPPeerPreservesMultipleFamilies` — session reconciler passes EVPN families through to generated BGPPeer
- [ ] `TestReconcilePopInfraGeneratesEVPNPeer` — full reconcile loop: BGPSession → BGPPeer with L2VPN/EVPN written to API server
- [ ] `TestPeerReconcilerEVPNAddressFamily` — EVPN flows from BGPPeer spec to `AddOrUpdatePeer` call
- [ ] `TestPeerReconcilerEVPNInheritedFromInstance` — BGPPeer with no explicit families inherits L2VPN/EVPN from BGPInstance
- [ ] All 8 Chainsaw e2e tests pass (`task test-e2e`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)