### PR TITLE
feat(bgp): add listenPort field to BGPInstance

### DIFF
--- a/api/bgp/v1alpha1/instance_types.go
+++ b/api/bgp/v1alpha1/instance_types.go
@@ -64,6 +64,15 @@ type BGPInstanceSpec struct {
 	// +optional
 	BestPath *BestPathConfig `json:"bestPath,omitempty"`
 
+	// ListenPort is the TCP port the BGP speaker listens on for incoming sessions.
+	// Defaults to 179 (standard BGP port). Set to -1 to disable the listener
+	// entirely, which is appropriate for speakers that only initiate outbound sessions.
+	//
+	// +kubebuilder:default=179
+	// +kubebuilder:validation:Maximum=65535
+	// +optional
+	ListenPort *int32 `json:"listenPort,omitempty"`
+
 	// RouteReflector configures this instance as a route reflector.
 	// Only valid in infra cluster role. Rejected in POP clusters.
 	//

--- a/api/bgp/v1alpha1/shared_types.go
+++ b/api/bgp/v1alpha1/shared_types.go
@@ -54,7 +54,7 @@ type ResolvedProviderConfig struct {
 	// +optional
 	RouterID string `json:"routerID,omitempty"`
 
-	// ListenPort is the port BGP listens on (179 for FRR, 0 for GoBGP which initiates only).
+	// ListenPort is the port the BGP speaker was configured to listen on.
 	// +optional
 	ListenPort *int32 `json:"listenPort,omitempty"`
 

--- a/config/crd/bgp.miloapis.com_bgpadvertisements.yaml
+++ b/config/crd/bgp.miloapis.com_bgpadvertisements.yaml
@@ -296,8 +296,8 @@ spec:
                           format: int64
                           type: integer
                         listenPort:
-                          description: ListenPort is the port BGP listens on (179
-                            for FRR, 0 for GoBGP which initiates only).
+                          description: ListenPort is the port the BGP speaker was
+                            configured to listen on.
                           format: int32
                           type: integer
                         passive:

--- a/config/crd/bgp.miloapis.com_bgpinstances.yaml
+++ b/config/crd/bgp.miloapis.com_bgpinstances.yaml
@@ -97,6 +97,15 @@ spec:
                     description: DeterministicMed enables deterministic MED comparison.
                     type: boolean
                 type: object
+              listenPort:
+                default: 179
+                description: |-
+                  ListenPort is the TCP port the BGP speaker listens on for incoming sessions.
+                  Defaults to 179 (standard BGP port). Set to -1 to disable the listener
+                  entirely, which is appropriate for speakers that only initiate outbound sessions.
+                format: int32
+                maximum: 65535
+                type: integer
               providerSelector:
                 description: ProviderSelector selects BGPProvider resources this instance
                   configures.
@@ -383,8 +392,8 @@ spec:
                           format: int64
                           type: integer
                         listenPort:
-                          description: ListenPort is the port BGP listens on (179
-                            for FRR, 0 for GoBGP which initiates only).
+                          description: ListenPort is the port the BGP speaker was
+                            configured to listen on.
                           format: int32
                           type: integer
                         passive:

--- a/config/crd/bgp.miloapis.com_bgppeers.yaml
+++ b/config/crd/bgp.miloapis.com_bgppeers.yaml
@@ -185,8 +185,9 @@ spec:
                 type: object
                 x-kubernetes-map-type: atomic
               remotePort:
-                description: RemotePort is the TCP port to connect to on the remote
-                  peer. Defaults to 179 (standard BGP) when unset.
+                description: |-
+                  RemotePort is the TCP port to connect to on the remote peer.
+                  Defaults to 179 (standard BGP) when unset.
                 format: int32
                 maximum: 65535
                 minimum: 1
@@ -414,8 +415,8 @@ spec:
                           format: int64
                           type: integer
                         listenPort:
-                          description: ListenPort is the port BGP listens on (179
-                            for FRR, 0 for GoBGP which initiates only).
+                          description: ListenPort is the port the BGP speaker was
+                            configured to listen on.
                           format: int32
                           type: integer
                         passive:

--- a/config/crd/bgp.miloapis.com_bgproutepolicies.yaml
+++ b/config/crd/bgp.miloapis.com_bgproutepolicies.yaml
@@ -389,8 +389,8 @@ spec:
                           format: int64
                           type: integer
                         listenPort:
-                          description: ListenPort is the port BGP listens on (179
-                            for FRR, 0 for GoBGP which initiates only).
+                          description: ListenPort is the port the BGP speaker was
+                            configured to listen on.
                           format: int32
                           type: integer
                         passive:

--- a/config/crd/bgp.miloapis.com_bgpsessions.yaml
+++ b/config/crd/bgp.miloapis.com_bgpsessions.yaml
@@ -189,9 +189,9 @@ spec:
                         to use for the generated BGPPeer.
                       type: string
                     remotePort:
-                      description: RemotePort is the TCP port to connect to on this
-                        peer. Passed through to the generated BGPPeer. Defaults to
-                        179 when unset.
+                      description: |-
+                        RemotePort is the TCP port to connect to on this peer.
+                        Passed through to the generated BGPPeer. Defaults to 179 when unset.
                       format: int32
                       maximum: 65535
                       minimum: 1

--- a/internal/controller/instance_reconciler.go
+++ b/internal/controller/instance_reconciler.go
@@ -119,17 +119,12 @@ func (r *InstanceReconciler) reconcileForProvider(
 			"RouterIDResolutionFailed", fmt.Sprintf("resolve router ID: %v", err))
 	}
 
-	// Determine listen port by daemon type.
-	var listenPort int32
-	switch bp.Spec.Type {
-	case "FRR":
-		listenPort = 179
-	case "GoBGP":
-		if instance.Spec.RouteReflector != nil {
-			listenPort = 1790
-		} else {
-			listenPort = -1 // Disable listener; worker nodes connect outbound to the RR only
-		}
+	// Determine listen port from spec. The API server applies the default (179)
+	// on admission so this is non-nil for all current objects; the fallback
+	// handles objects created before the default was introduced.
+	var listenPort int32 = 179
+	if instance.Spec.ListenPort != nil {
+		listenPort = *instance.Spec.ListenPort
 	}
 
 	// Convert address families.

--- a/internal/controller/instance_reconciler_test.go
+++ b/internal/controller/instance_reconciler_test.go
@@ -34,25 +34,92 @@ func (s *stubProvider) Capabilities(_ context.Context) (provider.CapabilitySet, 
 	return provider.CapabilitySet{}, nil
 }
 
-// TestListenPortByDaemonType verifies that reconcileForProvider passes the
-// correct listen port to ConfigureSpeaker for each daemon type:
-//   - FRR                   → 179   (standard BGP port; FRR owns the underlay)
-//   - GoBGP/worker          → -1    (listener disabled; connects outbound to RR only)
-//   - GoBGP/route-reflector → 1790  (non-standard port avoids conflict with FRR's 179)
-//   - other                 → 0     (switch default; zero value for int32)
-func TestListenPortByDaemonType(t *testing.T) {
+// TestListenPortPassthrough verifies that reconcileForProvider passes spec.listenPort
+// to ConfigureSpeaker unchanged, and falls back to 179 when the field is nil
+// (objects created before the API default was introduced).
+func TestListenPortPassthrough(t *testing.T) {
+	p179 := int32(179)
+	pNeg1 := int32(-1)
+	p1790 := int32(1790)
+	p1179 := int32(1179)
+
+	tests := []struct {
+		name           string
+		listenPort     *int32
+		wantListenPort int32
+	}{
+		{name: "standard port", listenPort: &p179, wantListenPort: 179},
+		{name: "disabled (-1)", listenPort: &pNeg1, wantListenPort: -1},
+		{name: "RR port", listenPort: &p1790, wantListenPort: 1790},
+		{name: "custom port", listenPort: &p1179, wantListenPort: 1179},
+		{name: "nil falls back to 179", listenPort: nil, wantListenPort: 179},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			stub := &stubProvider{}
+			reg := provider.NewRegistry()
+			reg.Set("test-provider", stub)
+
+			instance := &bgpv1alpha1.BGPInstance{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-instance"},
+				Spec: bgpv1alpha1.BGPInstanceSpec{
+					ASNumber:       64512,
+					RouterIDSource: "Manual",
+					RouterID:       "10.0.0.1",
+					ListenPort:     tc.listenPort,
+					ProviderSelector: metav1.LabelSelector{
+						MatchLabels: map[string]string{"type": "gobgp"},
+					},
+				},
+			}
+			bp := &providersv1alpha1.BGPProvider{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:   "test-provider",
+					Labels: map[string]string{"type": "gobgp"},
+				},
+				Spec: providersv1alpha1.BGPProviderSpec{Type: "GoBGP"},
+			}
+
+			fakeClient := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithObjects(instance, bp).
+				WithStatusSubresource(instance).
+				Build()
+
+			r := &InstanceReconciler{
+				Client:   fakeClient,
+				Scheme:   scheme,
+				Registry: reg,
+			}
+
+			if err := r.reconcileForProvider(context.Background(), instance, bp); err != nil {
+				t.Fatalf("reconcileForProvider: %v", err)
+			}
+
+			if stub.lastSpec.ListenPort != tc.wantListenPort {
+				t.Errorf("ListenPort = %d, want %d", stub.lastSpec.ListenPort, tc.wantListenPort)
+			}
+		})
+	}
+}
+
+// TestListenPortExplicitOverride is preserved for its daemon-type coverage:
+// the port is always sourced from spec.listenPort regardless of daemon type or RR config.
+func TestListenPortExplicitOverride(t *testing.T) {
 	rrSpec := &bgpv1alpha1.RouteReflectorConfig{ClusterID: "1.0.0.1"}
+	port := int32(1179)
 
 	tests := []struct {
 		name           string
 		daemonType     string
 		routeReflector *bgpv1alpha1.RouteReflectorConfig
+		listenPort     *int32
 		wantListenPort int32
 	}{
-		{name: "FRR", daemonType: "FRR", wantListenPort: 179},
-		{name: "GoBGP/worker", daemonType: "GoBGP", wantListenPort: -1},
-		{name: "GoBGP/route-reflector", daemonType: "GoBGP", routeReflector: rrSpec, wantListenPort: 1790},
-		{name: "unknown", daemonType: "unknown", wantListenPort: 0},
+		{name: "GoBGP worker", daemonType: "GoBGP", listenPort: &port, wantListenPort: 1179},
+		{name: "GoBGP RR", daemonType: "GoBGP", routeReflector: rrSpec, listenPort: &port, wantListenPort: 1179},
+		{name: "FRR", daemonType: "FRR", listenPort: &port, wantListenPort: 1179},
 	}
 
 	for _, tc := range tests {
@@ -68,6 +135,7 @@ func TestListenPortByDaemonType(t *testing.T) {
 					RouterIDSource: "Manual",
 					RouterID:       "10.0.0.1",
 					RouteReflector: tc.routeReflector,
+					ListenPort:     tc.listenPort,
 					ProviderSelector: metav1.LabelSelector{
 						MatchLabels: map[string]string{"daemon": tc.daemonType},
 					},
@@ -98,8 +166,7 @@ func TestListenPortByDaemonType(t *testing.T) {
 			}
 
 			if stub.lastSpec.ListenPort != tc.wantListenPort {
-				t.Errorf("daemon %s: ListenPort = %d, want %d",
-					tc.name, stub.lastSpec.ListenPort, tc.wantListenPort)
+				t.Errorf("ListenPort = %d, want %d", stub.lastSpec.ListenPort, tc.wantListenPort)
 			}
 		})
 	}

--- a/internal/provider/gobgp/provider_test.go
+++ b/internal/provider/gobgp/provider_test.go
@@ -516,6 +516,36 @@ func TestConfigureSpeaker(t *testing.T) {
 		}
 	})
 
+	t.Run("running with mismatched ListenPort: stops then restarts", func(t *testing.T) {
+		fake := &fakeGoBgpClient{
+			getBgpFn: func(_ context.Context, _ *gobgpapi.GetBgpRequest, _ ...grpc.CallOption) (*gobgpapi.GetBgpResponse, error) {
+				return &gobgpapi.GetBgpResponse{Global: &gobgpapi.Global{
+					Asn: 64512, RouterId: "10.0.0.1", ListenPort: 179,
+				}}, nil
+			},
+		}
+		p := &Provider{client: fake}
+
+		restarted, err := p.ConfigureSpeaker(context.Background(), provider.SpeakerSpec{
+			ASNumber: 64512, RouterID: "10.0.0.1", ListenPort: 1790,
+		})
+		if err != nil {
+			t.Fatalf("ConfigureSpeaker: unexpected error: %v", err)
+		}
+		if !restarted {
+			t.Error("restarted = false, want true (ListenPort changed)")
+		}
+		if fake.stopBgpN != 1 {
+			t.Errorf("StopBgp called %d time(s), want 1", fake.stopBgpN)
+		}
+		if fake.startBgpReq == nil {
+			t.Fatal("StartBgp not called")
+		}
+		if fake.startBgpReq.Global.ListenPort != 1790 {
+			t.Errorf("StartBgp Global.ListenPort = %d, want 1790", fake.startBgpReq.Global.ListenPort)
+		}
+	})
+
 	t.Run("running with mismatched ASN: stops then restarts", func(t *testing.T) {
 		fake := &fakeGoBgpClient{
 			getBgpFn: func(_ context.Context, _ *gobgpapi.GetBgpRequest, _ ...grpc.CallOption) (*gobgpapi.GetBgpResponse, error) {


### PR DESCRIPTION
## Overview

This patch adds a new field to `BGPInstance` that allows an operator to change the default port the BGP process listens for connections on.  This patch is imperative for deployments that have more than one BGP listening daemon on a single instance.  

## Summary

- Adds `spec.listenPort` to `BGPInstanceSpec` so operators control which TCP port the BGP speaker listens on
- Defaults to `179` (standard BGP port) via a kubebuilder server-side default; set to `-1` to disable the listener entirely
- Removes the implicit daemon-type auto-derive logic (GoBGP worker → -1, GoBGP RR → 1790) in favour of explicit configuration
- Cleans up daemon-specific language (`179 for FRR, 0 for GoBGP`) from `ResolvedProviderConfig.listenPort` description

## Test plan

- [ ] `TestListenPortPassthrough` — verifies the field is passed through to `ConfigureSpeaker` unchanged across standard, disabled (-1), RR, custom, and nil-fallback cases
- [ ] `TestListenPortExplicitOverride` — verifies daemon type and RR config have no effect; port always comes from `spec.listenPort`
- [ ] `TestConfigureSpeaker/running with mismatched ListenPort` — verifies a listen port change triggers GoBGP StopBgp/StartBgp
- [ ] `go test ./internal/controller/... ./internal/provider/gobgp/...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)