### PR TITLE
refactor(provider): rename SpeakerSpec/ConfigureSpeaker to InstanceSpec/ConfigureInstance

### DIFF
--- a/docs/diagrams/crd-provider-mapping.md
+++ b/docs/diagrams/crd-provider-mapping.md
@@ -1,0 +1,114 @@
+# CRD to BGPProvider Struct Mapping
+
+This diagram shows how Kubernetes CRDs flow through reconcilers, get converted to provider structs, and are dispatched to the `Provider` interface.
+
+```mermaid
+flowchart TD
+    subgraph CRDs["Kubernetes CRDs (bgp.miloapis.com/v1alpha1)"]
+        BGPProvider["BGPProvider\n(providers.miloapis.com)\n─────────────────\nspec.type: FRR|GoBGP\nspec.endpoint"]
+        BGPInstance["BGPInstance\n─────────────────\nspec.asNumber\nspec.routerID\nspec.listenPort\nspec.addressFamilies[]\nspec.timers\nspec.bestPath\nspec.routeReflector"]
+        BGPPeer["BGPPeer\n─────────────────\nspec.address\nspec.asNumber\nspec.addressFamilies[]\nspec.timers\nspec.allowAsIn\nspec.routeReflectorClient\nspec.passive\nspec.ebgpMultihop\nspec.ttlSecurity\nspec.remotePort\nspec.passwordRef"]
+        BGPAdvertisement["BGPAdvertisement\n─────────────────\nspec.prefixes[]\nspec.peerSelector"]
+        BGPRoutePolicy["BGPRoutePolicy\n─────────────────\nspec.priority\nspec.importStatements[]\nspec.exportStatements[]"]
+        BGPSession["BGPSession\n─────────────────\nspec.localPeerRef\nspec.externalPeerRef"]
+        BGPExternalPeer["BGPExternalPeer\n─────────────────\nspec.address\nspec.asNumber"]
+    end
+
+    subgraph Reconcilers["Controllers (internal/controller)"]
+        ProviderRec["ProviderReconciler\nprovider_reconciler.go"]
+        InstanceRec["InstanceReconciler\ninstance_reconciler.go"]
+        PeerRec["PeerReconciler\npeer_reconciler.go"]
+        AdvRec["AdvertisementReconciler\nadvertisement_reconciler.go"]
+        PolicyRec["RoutePolicyReconciler\nroutepolicy_reconciler.go"]
+        SessionRec["SessionReconciler\nsession_reconciler.go"]
+    end
+
+    subgraph ProviderStructs["Provider Structs (internal/provider/provider.go)"]
+        InstanceSpec["InstanceSpec\n─────────────────\nASNumber uint32\nRouterID string\nListenPort int32\nFamilies []AddressFamily\nTimers\nBestPath\nRouteReflector"]
+        PeerSpec["PeerSpec\n─────────────────\nAddress string\nASNumber uint32\nFamilies []AddressFamily\nTimers\nAllowAsIn uint32\nRouteReflectorClient bool\nPassive bool\nEBGPMultihop uint32\nTTLSecurity uint32\nPassword string\nRemotePort uint32"]
+        AdvSpec["AdvertisementSpec\n─────────────────\nPrefixes []string\nPeerAddresses []string"]
+        PolicySpec["PolicySpec\n─────────────────\nName string\nPriority int32\nImportStatements []\nExportStatements []"]
+        PolicyStatement["PolicyStatement\n─────────────────\nName string\nConditions PolicyConditions\nActions PolicyActions"]
+    end
+
+    subgraph Interface["Provider Interface (internal/provider/provider.go:41)"]
+        PI["provider.Provider\n────────────────────────────────\nConfigureInstance(InstanceSpec)\nAddOrUpdatePeer(PeerSpec)\nDeletePeer(address string)\nAddOrUpdateAdvertisement(AdvSpec)\nDeleteAdvertisement(prefix string)\nAddOrUpdatePolicy(PolicySpec)\nDeletePolicy(policyName string)\nReady()\nCapabilities()"]
+    end
+
+    subgraph Implementations["Provider Implementations"]
+        GoBGP["GoBGP\ninternal/provider/gobgp/"]
+        FRR["FRR\ninternal/provider/frr/"]
+    end
+
+    subgraph Registry["Provider Registry"]
+        Reg["provider.Registry\nmap: name → Provider"]
+    end
+
+    %% CRD → Reconciler
+    BGPProvider --> ProviderRec
+    BGPInstance --> InstanceRec
+    BGPPeer --> PeerRec
+    BGPAdvertisement --> AdvRec
+    BGPRoutePolicy --> PolicyRec
+    BGPSession --> SessionRec
+    BGPExternalPeer --> SessionRec
+
+    %% Session generates BGPPeer (no direct provider call)
+    SessionRec -. "generates BGPPeer\n+ BGPSession CRDs" .-> BGPPeer
+
+    %% Reconciler → Provider Struct conversion
+    InstanceRec --> InstanceSpec
+    PeerRec --> PeerSpec
+    AdvRec --> AdvSpec
+    PolicyRec --> PolicySpec
+    PolicySpec --> PolicyStatement
+
+    %% Provider Struct → Interface Method
+    InstanceSpec --> |"ConfigureInstance()"| PI
+    PeerSpec --> |"AddOrUpdatePeer()\nDeletePeer()"| PI
+    AdvSpec --> |"AddOrUpdateAdvertisement()\nDeleteAdvertisement()"| PI
+    PolicySpec --> |"AddOrUpdatePolicy()\nDeletePolicy()"| PI
+
+    %% Provider registration
+    ProviderRec --> |"factory(type, endpoint)\nRegistry.Set()"| Reg
+    Reg --> |"Registry.Get()"| PI
+
+    %% Interface → Implementation
+    PI --> GoBGP
+    PI --> FRR
+```
+
+## Key Reference Resolution
+
+Before building provider structs, reconcilers resolve indirect references:
+
+| Reconciler | Resolution Step |
+|---|---|
+| **InstanceReconciler** | RouterID: resolves from node annotation or Downward API env `NAMESPACE` |
+| **PeerReconciler** | Timers: merges instance-level defaults with peer-level overrides |
+| **PeerReconciler** | Password: fetches from `spec.passwordRef` Secret |
+| **AdvertisementReconciler** | PeerAddresses: expands `spec.peerSelector` label query → `[]string` of peer IPs |
+| **ProviderReconciler** | Endpoint: extracted from `BGPProvider.Spec`, passed to `ProviderFactory` |
+
+## CRD Ownership Hierarchy
+
+```
+BGPProvider  ←── BGPInstance (providerSelector)
+                      ↑
+              BGPPeer (instanceRef + providerRef/Selector)
+              BGPAdvertisement (instanceRef)
+              BGPRoutePolicy (instanceRef)
+                      ↑
+              BGPSession → generates BGPPeer + links BGPExternalPeer
+```
+
+## Files
+
+| Component | Path |
+|---|---|
+| BGP CRD types | `api/bgp/v1alpha1/*_types.go` |
+| Provider CRD type | `api/providers/v1alpha1/provider_types.go` |
+| Provider interface + structs | `internal/provider/provider.go` |
+| Reconcilers | `internal/controller/*_reconciler.go` |
+| GoBGP implementation | `internal/provider/gobgp/` |
+| FRR implementation | `internal/provider/frr/` |

--- a/internal/controller/instance_reconciler.go
+++ b/internal/controller/instance_reconciler.go
@@ -27,7 +27,7 @@ import (
 
 // InstanceReconciler reconciles BGPInstance resources.
 // It resolves the router ID, derives per-provider speaker configuration, and calls
-// provider.ConfigureSpeaker for each matched BGPProvider.
+// provider.ConfigureInstance for each matched BGPProvider.
 type InstanceReconciler struct {
 	client.Client
 	Scheme   *runtime.Scheme
@@ -149,7 +149,7 @@ func (r *InstanceReconciler) reconcileForProvider(
 		rrConfig = &provider.RouteReflectorConfig{ClusterID: rr.ClusterID}
 	}
 
-	spec := provider.SpeakerSpec{
+	spec := provider.InstanceSpec{
 		ASNumber:       instance.Spec.ASNumber,
 		RouterID:       routerID,
 		ListenPort:     listenPort,
@@ -159,10 +159,10 @@ func (r *InstanceReconciler) reconcileForProvider(
 		RouteReflector: rrConfig,
 	}
 
-	restarted, err := impl.ConfigureSpeaker(ctx, spec)
+	restarted, err := impl.ConfigureInstance(ctx, spec)
 	if err != nil {
 		return r.writeInstanceProviderStatus(ctx, instance, bp.Name, bp.Spec.Type, false,
-			"ConfigurationFailed", fmt.Sprintf("ConfigureSpeaker: %v", err))
+			"ConfigurationFailed", fmt.Sprintf("ConfigureInstance: %v", err))
 	}
 
 	// When the remote agent was restarted, all peer state is wiped. Bump an

--- a/internal/controller/instance_reconciler_test.go
+++ b/internal/controller/instance_reconciler_test.go
@@ -12,12 +12,12 @@ import (
 	"go.miloapis.com/cosmos/internal/provider"
 )
 
-// stubProvider records the most recent ConfigureSpeaker call for inspection.
+// stubProvider records the most recent ConfigureInstance call for inspection.
 type stubProvider struct {
-	lastSpec provider.SpeakerSpec
+	lastSpec provider.InstanceSpec
 }
 
-func (s *stubProvider) ConfigureSpeaker(_ context.Context, spec provider.SpeakerSpec) (bool, error) {
+func (s *stubProvider) ConfigureInstance(_ context.Context, spec provider.InstanceSpec) (bool, error) {
 	s.lastSpec = spec
 	return false, nil
 }
@@ -35,7 +35,7 @@ func (s *stubProvider) Capabilities(_ context.Context) (provider.CapabilitySet, 
 }
 
 // TestListenPortPassthrough verifies that reconcileForProvider passes spec.listenPort
-// to ConfigureSpeaker unchanged, and falls back to 179 when the field is nil
+// to ConfigureInstance unchanged, and falls back to 179 when the field is nil
 // (objects created before the API default was introduced).
 func TestListenPortPassthrough(t *testing.T) {
 	p179 := int32(179)
@@ -172,9 +172,9 @@ func TestListenPortExplicitOverride(t *testing.T) {
 	}
 }
 
-// TestSpeakerSpecPropagation verifies that reconcileForProvider propagates AS
-// number and router ID from the BGPInstance spec to ConfigureSpeaker unchanged.
-func TestSpeakerSpecPropagation(t *testing.T) {
+// TestInstanceSpecPropagation verifies that reconcileForProvider propagates AS
+// number and router ID from the BGPInstance spec to ConfigureInstance unchanged.
+func TestInstanceSpecPropagation(t *testing.T) {
 	stub := &stubProvider{}
 	pool := provider.NewPool()
 	pool.SetForTest("test-provider", stub)

--- a/internal/controller/peer_reconciler_test.go
+++ b/internal/controller/peer_reconciler_test.go
@@ -17,7 +17,7 @@ type peerRecordingProvider struct {
 	lastPeerSpec provider.PeerSpec
 }
 
-func (p *peerRecordingProvider) ConfigureSpeaker(_ context.Context, _ provider.SpeakerSpec) (bool, error) {
+func (p *peerRecordingProvider) ConfigureInstance(_ context.Context, _ provider.InstanceSpec) (bool, error) {
 	return false, nil
 }
 func (p *peerRecordingProvider) AddOrUpdatePeer(_ context.Context, spec provider.PeerSpec) error {

--- a/internal/provider/grpc.go
+++ b/internal/provider/grpc.go
@@ -22,8 +22,8 @@ func NewGRPCProvider(conn grpc.ClientConnInterface) *GRPCProvider {
 	return &GRPCProvider{client: providerv1alpha1.NewBGPProviderServiceClient(conn)}
 }
 
-func (g *GRPCProvider) ConfigureSpeaker(ctx context.Context, spec SpeakerSpec) (bool, error) {
-	resp, err := g.client.ConfigureSpeaker(ctx, speakerSpecToProto(spec))
+func (g *GRPCProvider) ConfigureInstance(ctx context.Context, spec InstanceSpec) (bool, error) {
+	resp, err := g.client.ConfigureSpeaker(ctx, instanceSpecToProto(spec))
 	if err != nil {
 		return false, grpcErr(err)
 	}

--- a/internal/provider/grpc_convert.go
+++ b/internal/provider/grpc_convert.go
@@ -4,7 +4,7 @@ import (
 	providerv1alpha1 "go.miloapis.com/cosmos/api/proto/bgp/provider/v1alpha1"
 )
 
-func speakerSpecToProto(spec SpeakerSpec) *providerv1alpha1.ConfigureSpeakerRequest {
+func instanceSpecToProto(spec InstanceSpec) *providerv1alpha1.ConfigureSpeakerRequest {
 	families := make([]*providerv1alpha1.AddressFamily, 0, len(spec.Families))
 	for _, af := range spec.Families {
 		families = append(families, &providerv1alpha1.AddressFamily{Afi: af.AFI, Safi: af.SAFI})

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -24,10 +24,13 @@ import (
 // once. This contract enables the controller to safely re-apply configuration
 // after a daemon restart without first querying existing state.
 type Provider interface {
-	// ConfigureSpeaker applies BGPInstance-level configuration. Idempotent.
-	// Returns (true, nil) when the remote agent was restarted; peers must be
-	// re-applied by the caller because a restart wipes all session state.
-	ConfigureSpeaker(ctx context.Context, spec SpeakerSpec) (restarted bool, err error)
+	// ConfigureInstance applies BGPInstance-level configuration. Idempotent.
+	// On daemons that require a restart to change AS or router-ID (e.g. GoBGP
+	// StartBgp/StopBgp), the implementation is responsible for detecting the
+	// change and performing the restart transparently.
+	// Returns (true, nil) when the daemon was restarted; peers must be re-applied
+	// by the caller because a restart wipes all session state.
+	ConfigureInstance(ctx context.Context, spec InstanceSpec) (restarted bool, err error)
 
 	// AddOrUpdatePeer configures a BGP session. Idempotent.
 	AddOrUpdatePeer(ctx context.Context, peer PeerSpec) error
@@ -63,12 +66,15 @@ type AddressFamily struct {
 	SAFI string // "Unicast" or "VPNUnicast"
 }
 
-// SpeakerSpec is the provider-level representation of BGPInstance configuration.
+// InstanceSpec is the provider-level representation of BGPInstance configuration.
 // It is derived by the controller from a BGPInstance and its associated BGPProvider.
-type SpeakerSpec struct {
-	ASNumber       int64
-	RouterID       string
-	ListenPort     int32
+type InstanceSpec struct {
+	ASNumber int64
+	RouterID string
+	// ListenPort is 179 for FRR (standard BGP port). For GoBGP, it is 1790 on the
+	// route reflector and -1 (listener disabled) on worker nodes, which only connect
+	// outbound to the RR.
+	ListenPort int32
 	Families       []AddressFamily
 	Timers         TimerConfig
 	BestPath       BestPathConfig


### PR DESCRIPTION
## Summary

- Renames `SpeakerSpec` → `InstanceSpec` and `ConfigureSpeaker` → `ConfigureInstance` on the `Provider` interface
- Aligns naming with the rest of the interface (`PeerSpec`, `AdvertisementSpec`, `PolicySpec`)
- Updates all call sites, stubs, and test functions accordingly
- Adds `docs/diagrams/crd-provider-mapping.md` with a Mermaid diagram showing how CRDs flow through reconcilers to provider structs and interface methods

## Test plan

- [ ] `go build ./...` passes
- [ ] `go test ./internal/...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)