### PR TITLE
refactor: remove daemon-specific references, reflect BGPProvider abstraction

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@
 
 Cosmos is a BGP control plane for Kubernetes. You define instances, sessions,
 advertisements, and VPCs as Kubernetes resources; the controller reconciles
-them into running [FRR][frr] and [GoBGP][gobgp] daemons on each node and
-programs learned routes into the kernel via [netlink][netlink].
+them into remote BGP agents on each node and programs learned routes into the
+kernel via [netlink][netlink].
 
 **API groups:**
 `bgp.miloapis.com/v1alpha1` · `providers.bgp.miloapis.com/v1alpha1` · `vpc.miloapis.com/v1alpha1`
@@ -14,14 +14,19 @@ programs learned routes into the kernel via [netlink][netlink].
 
 ## How it works
 
-Cosmos runs as a DaemonSet in the `bgp-system` namespace. Each node runs two
-BGP planes:
+Cosmos runs as a DaemonSet in the `bgp-system` namespace. On each node, one or
+more `BGPProvider` resources represent remote BGP agent processes that cosmos
+connects to via gRPC. Each provider exposes the `BGPProviderService` proto
+interface; cosmos has no built-in knowledge of what runs behind it.
 
-- **Underlay** — [FRR][frr] handles IPv6 unicast sessions to top-of-rack switches
-- **Overlay** — [GoBGP][gobgp] handles VPNv4/VPNv6 sessions to regional route reflectors
+BGP CRDs (`BGPInstance`, `BGPPeer`, `BGPAdvertisement`, `BGPRoutePolicy`) select
+providers by label and marshal configuration calls through the provider interface.
+The remote agents implement whatever BGP daemon logic they need — cosmos only
+cares that they satisfy the gRPC contract.
 
 At startup the controller auto-bootstraps a `BGPProvider` resource for each
-daemon. These providers are the unit of targeting for all other resources.
+local agent endpoint. These providers are the unit of targeting for all other
+resources.
 
 Cosmos operates in a multi-cluster model:
 
@@ -31,7 +36,7 @@ Cosmos operates in a multi-cluster model:
 2. [Karmada][karmada] propagates `BGPSession` resources to **POP and infra
    clusters**.
 3. On each member cluster, the `SessionReconciler` generates `BGPPeer` resources
-   from the propagated sessions, and the `PeerReconciler` configures the daemons
+   from the propagated sessions, and the `PeerReconciler` configures the agents
    over [gRPC][grpc].
 
 The controller has no built-in knowledge of datacenter topology — all topology
@@ -41,12 +46,19 @@ is expressed through CRDs and Karmada propagation policies.
 
 ## Key features
 
-- **Dual-plane per node.** FRR underlay (IPv6 unicast) and GoBGP overlay (VPNv4/VPNv6) managed independently.
-- **Provider abstraction.** `BGPProvider` resources decouple topology from daemon type; FRR and GoBGP are both supported.
-- **Auto-bootstrapped providers.** No manual daemon registration; the controller creates `BGPProvider` resources at startup.
-- **Multi-cluster propagation.** Sessions are written once in the management cluster and distributed by Karmada.
+- **Provider abstraction.** `BGPProvider` resources decouple topology from agent
+  implementation. Cosmos drives any agent that implements the gRPC provider interface.
+- **Label-driven dispatch.** All resources select providers via `providerSelector`.
+  Topology is expressed through labels, not hardcoded names.
+- **Auto-bootstrapped providers.** No manual agent registration; the controller
+  creates `BGPProvider` resources at startup.
+- **Multi-cluster propagation.** Sessions are written once in the management
+  cluster and distributed by Karmada.
+- **Per-provider status.** Every BGP resource tracks reconciliation state
+  independently per provider.
 - **CNI-independent.** Works with any [CNI][cni] or none at all.
-- **VPC primitives.** `VPC` and `VPCAttachment` CRDs model virtual networks and their interface bindings.
+- **VPC primitives.** `VPC` and `VPCAttachment` CRDs model virtual networks and
+  their interface bindings.
 
 ---
 
@@ -57,8 +69,7 @@ is expressed through CRDs and Karmada propagation policies.
 - `kubectl` configured for your clusters
 - Container images accessible to your clusters:
   - `ghcr.io/milo-os/cosmos:latest` — controller
-  - An FRR image with northbound gRPC enabled
-  - A GoBGP daemon image
+  - One or more remote BGP agent images that implement the `BGPProviderService` proto
 
 ---
 
@@ -72,7 +83,7 @@ kubectl apply -k config/deploy
 ```
 
 After the DaemonSet pods become ready, verify that `BGPProvider` resources were
-auto-bootstrapped (one per daemon per node):
+auto-bootstrapped (one per agent per node):
 
 ```bash
 kubectl get bgpproviders
@@ -89,7 +100,7 @@ metadata:
 spec:
   providerSelector:
     matchLabels:
-      bgp.miloapis.com/daemon: frr
+      bgp.datum.net/plane: underlay
   asNumber: 65000
   addressFamilies:
     - afi: IPv6
@@ -108,7 +119,7 @@ spec:
   fromProviderSelector:
     matchLabels:
       bgp.miloapis.com/node: node-1
-      bgp.miloapis.com/daemon: frr
+      bgp.datum.net/plane: underlay
   fromInstanceRef: underlay
   toPeers:
     - address: "2001:db8:fabric::1"
@@ -146,7 +157,7 @@ For a complete walkthrough, see the [Getting Started guide](docs/getting-started
 
 | Resource      | Short name | Description                                                              |
 |---------------|------------|--------------------------------------------------------------------------|
-| `BGPProvider` | `bgpp`     | One BGP daemon instance (FRR or GoBGP). Auto-bootstrapped at startup.   |
+| `BGPProvider` | `bgpp`     | One remote BGP agent instance. Auto-bootstrapped at startup.             |
 
 ### VPC — `vpc.miloapis.com/v1alpha1`
 
@@ -203,8 +214,8 @@ docker build -f build/Dockerfile -t ghcr.io/milo-os/cosmos:dev .
 ### Examples
 
 - [BGPProvider (auto-bootstrapped)](docs/examples/pop-bgpprovider-auto.yaml)
-- [BGPInstance — underlay FRR](docs/examples/pop-bgpinstance-underlay.yaml)
-- [BGPInstance — overlay GoBGP](docs/examples/pop-bgpinstance-overlay.yaml)
+- [BGPInstance — underlay](docs/examples/pop-bgpinstance-underlay.yaml)
+- [BGPInstance — overlay](docs/examples/pop-bgpinstance-overlay.yaml)
 - [BGPInstance — infra route reflector](docs/examples/infra-bgpinstance-rr.yaml)
 - [BGPExternalPeer — ToR switch](docs/examples/mgmt-bgpexternalpeer-tor.yaml)
 - [BGPSession — underlay to ToR](docs/examples/mgmt-bgpsession-underlay-tor.yaml)
@@ -220,8 +231,6 @@ docker build -f build/Dockerfile -t ghcr.io/milo-os/cosmos:dev .
 
 <!-- References -->
 [bgp]: https://datatracker.ietf.org/doc/html/rfc4271
-[frr]: https://frrouting.org/
-[gobgp]: https://github.com/osrg/gobgp
 [grpc]: https://grpc.io/
 [karmada]: https://karmada.io/
 [netlink]: https://man7.org/linux/man-pages/man7/netlink.7.html

--- a/api/bgp/v1alpha1/advertisement_types.go
+++ b/api/bgp/v1alpha1/advertisement_types.go
@@ -24,7 +24,7 @@ type BGPAdvertisement struct {
 // BGPAdvertisementSpec defines the desired advertisement state.
 type BGPAdvertisementSpec struct {
 	// InstanceRef is the name of the BGPInstance to advertise through.
-	// Must reference a BGPInstance bound to FRR providers with Unicast families.
+	// Must reference a BGPInstance bound to providers with Unicast address families.
 	InstanceRef string `json:"instanceRef"`
 
 	// Prefixes is the list of IPv4 or IPv6 unicast CIDR blocks to advertise.

--- a/api/bgp/v1alpha1/shared_types.go
+++ b/api/bgp/v1alpha1/shared_types.go
@@ -31,7 +31,7 @@ type ProviderStatus struct {
 	// ProviderName is the name of the BGPProvider this entry describes.
 	ProviderName string `json:"providerName"`
 
-	// Daemon is the daemon type (FRR or GoBGP).
+	// Daemon is the agent type reported by the BGPProvider.
 	Daemon string `json:"daemon"`
 
 	// Conditions are the per-provider conditions.

--- a/api/bgp/v1alpha1/vrf_types.go
+++ b/api/bgp/v1alpha1/vrf_types.go
@@ -4,7 +4,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// BGPVRFInstance configures an L2VPN EVPN VRF on GoBGP providers matched by
+// BGPVRFInstance configures an L2VPN EVPN VRF on providers matched by
 // spec.providerSelector. The referenced BGPInstance must have L2VPN/EVPN in
 // its addressFamilies.
 //
@@ -31,7 +31,7 @@ type BGPVRFInstanceSpec struct {
 	InstanceRef string `json:"instanceRef"`
 
 	// ProviderSelector selects the BGPProvider resources to configure this VRF on.
-	// Only GoBGP providers support VRF configuration.
+	// The matched providers must support the L2VPN/EVPN address family.
 	ProviderSelector metav1.LabelSelector `json:"providerSelector"`
 
 	// RouteDistinguisher uniquely identifies this VRF in the BGP control plane.

--- a/api/bgp/v1alpha1/vrf_types_test.go
+++ b/api/bgp/v1alpha1/vrf_types_test.go
@@ -17,7 +17,7 @@ func newTestVRF() *BGPVRFInstance {
 		Spec: BGPVRFInstanceSpec{
 			InstanceRef: "overlay",
 			ProviderSelector: metav1.LabelSelector{
-				MatchLabels: map[string]string{"daemon": "GoBGP"},
+				MatchLabels: map[string]string{"plane": "overlay"},
 			},
 			RouteDistinguisher: "65000:100",
 			ImportRouteTargets: []RouteTarget{{Value: "65000:100"}},
@@ -35,7 +35,7 @@ func TestBGPVRFInstanceDeepCopy(t *testing.T) {
 	// Mutate dup — original must be unaffected.
 	dup.Spec.RouteDistinguisher = "65001:200"
 	dup.Spec.ImportRouteTargets[0].Value = "65001:200"
-	dup.Spec.ProviderSelector.MatchLabels["daemon"] = "FRR"
+	dup.Spec.ProviderSelector.MatchLabels["plane"] = "underlay"
 
 	if orig.Spec.RouteDistinguisher != "65000:100" {
 		t.Errorf("RouteDistinguisher mutated: got %q", orig.Spec.RouteDistinguisher)
@@ -43,8 +43,8 @@ func TestBGPVRFInstanceDeepCopy(t *testing.T) {
 	if orig.Spec.ImportRouteTargets[0].Value != "65000:100" {
 		t.Errorf("ImportRouteTargets[0] mutated: got %q", orig.Spec.ImportRouteTargets[0].Value)
 	}
-	if orig.Spec.ProviderSelector.MatchLabels["daemon"] != "GoBGP" {
-		t.Errorf("ProviderSelector.MatchLabels mutated: got %q", orig.Spec.ProviderSelector.MatchLabels["daemon"])
+	if orig.Spec.ProviderSelector.MatchLabels["plane"] != "overlay" {
+		t.Errorf("ProviderSelector.MatchLabels mutated: got %q", orig.Spec.ProviderSelector.MatchLabels["plane"])
 	}
 }
 

--- a/cmd/cosmos-operator/main.go
+++ b/cmd/cosmos-operator/main.go
@@ -50,7 +50,7 @@ func newRootCommand() *cobra.Command {
 		Long: `Cosmos reconciles network CRDs against independently-running BGP daemons.
 It reconciles BGPProvider, BGPInstance, BGPPeer, BGPAdvertisement, BGPRoutePolicy,
 and BGPExternalPeer CRDs. BGPProvider resources specify the gRPC endpoint of a
-pre-existing daemon (FRR or GoBGP) that cosmos connects to.`,
+remote BGP agent that implements the BGPProviderService proto interface.`,
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return run(cmd.Context(), opts)

--- a/config/crd/bgp.miloapis.com_bgpadvertisements.yaml
+++ b/config/crd/bgp.miloapis.com_bgpadvertisements.yaml
@@ -54,7 +54,7 @@ spec:
               instanceRef:
                 description: |-
                   InstanceRef is the name of the BGPInstance to advertise through.
-                  Must reference a BGPInstance bound to FRR providers with Unicast families.
+                  Must reference a BGPInstance bound to providers with Unicast address families.
                 type: string
               peerSelector:
                 description: |-
@@ -247,7 +247,7 @@ spec:
                       - type
                       x-kubernetes-list-type: map
                     daemon:
-                      description: Daemon is the daemon type (FRR or GoBGP).
+                      description: Daemon is the agent type reported by the BGPProvider.
                       type: string
                     providerName:
                       description: ProviderName is the name of the BGPProvider this

--- a/config/crd/bgp.miloapis.com_bgpinstances.yaml
+++ b/config/crd/bgp.miloapis.com_bgpinstances.yaml
@@ -341,7 +341,7 @@ spec:
                       - type
                       x-kubernetes-list-type: map
                     daemon:
-                      description: Daemon is the daemon type (FRR or GoBGP).
+                      description: Daemon is the agent type reported by the BGPProvider.
                       type: string
                     providerName:
                       description: ProviderName is the name of the BGPProvider this

--- a/config/crd/bgp.miloapis.com_bgppeers.yaml
+++ b/config/crd/bgp.miloapis.com_bgppeers.yaml
@@ -366,7 +366,7 @@ spec:
                       - type
                       x-kubernetes-list-type: map
                     daemon:
-                      description: Daemon is the daemon type (FRR or GoBGP).
+                      description: Daemon is the agent type reported by the BGPProvider.
                       type: string
                     providerName:
                       description: ProviderName is the name of the BGPProvider this

--- a/config/crd/bgp.miloapis.com_bgproutepolicies.yaml
+++ b/config/crd/bgp.miloapis.com_bgproutepolicies.yaml
@@ -340,7 +340,7 @@ spec:
                       - type
                       x-kubernetes-list-type: map
                     daemon:
-                      description: Daemon is the daemon type (FRR or GoBGP).
+                      description: Daemon is the agent type reported by the BGPProvider.
                       type: string
                     providerName:
                       description: ProviderName is the name of the BGPProvider this

--- a/config/crd/bgp.miloapis.com_bgpvrfinstances.yaml
+++ b/config/crd/bgp.miloapis.com_bgpvrfinstances.yaml
@@ -30,7 +30,7 @@ spec:
     schema:
       openAPIV3Schema:
         description: |-
-          BGPVRFInstance configures an L2VPN EVPN VRF on GoBGP providers matched by
+          BGPVRFInstance configures an L2VPN EVPN VRF on providers matched by
           spec.providerSelector. The referenced BGPInstance must have L2VPN/EVPN in
           its addressFamilies.
         properties:
@@ -112,7 +112,7 @@ spec:
               providerSelector:
                 description: |-
                   ProviderSelector selects the BGPProvider resources to configure this VRF on.
-                  Only GoBGP providers support VRF configuration.
+                  The matched providers must support the L2VPN/EVPN address family.
                 properties:
                   matchExpressions:
                     description: matchExpressions is a list of label selector requirements.
@@ -306,7 +306,7 @@ spec:
                       - type
                       x-kubernetes-list-type: map
                     daemon:
-                      description: Daemon is the daemon type (FRR or GoBGP).
+                      description: Daemon is the agent type reported by the BGPProvider.
                       type: string
                     providerName:
                       description: ProviderName is the name of the BGPProvider this
@@ -355,8 +355,8 @@ spec:
                           format: int64
                           type: integer
                         listenPort:
-                          description: ListenPort is the port BGP listens on (179
-                            for FRR, 0 for GoBGP which initiates only).
+                          description: ListenPort is the port the BGP speaker
+                            listens on.
                           format: int32
                           type: integer
                         passive:

--- a/docs/api/bgp.md
+++ b/docs/api/bgp.md
@@ -12,20 +12,28 @@ stage: alpha
 
 ## 1. Overview
 
-Cosmos is the BGP control plane for the Datum.net fleet. It manages two distinct BGP planes:
+Cosmos is the BGP control plane for the Datum.net fleet. BGP CRDs marshal
+configuration calls to `BGPProvider` resources. Each `BGPProvider` points to a
+remote agent that implements the `BGPProviderService` gRPC interface. Cosmos has
+no built-in knowledge of what daemon or process runs behind a provider — it only
+cares that the endpoint satisfies the gRPC contract.
 
-| Plane | Daemon | Purpose |
-|-------|--------|---------|
-| **Underlay** | FRR | IPv6 unicast fabric routing between nodes and top-of-rack switches |
-| **Overlay** | GoBGP | L3VPN (VPNv4/VPNv6) distribution for tenant workloads |
+The fleet uses two BGP planes per node:
 
-Each plane is driven by a separate BGP daemon instance, selected by label. The two planes run independently on the same nodes — the underlay provides reachability; the overlay distributes VPN routes over that reachable fabric.
+| Plane | Purpose |
+|-------|---------|
+| **Underlay** | IPv6 unicast fabric routing between nodes and top-of-rack switches |
+| **Overlay** | L3VPN (VPNv4/VPNv6) distribution for tenant workloads |
+
+Each plane is represented by a separate `BGPProvider` resource with plane-specific
+labels. `BGPInstance`, `BGPPeer`, and other resources target providers by label
+selector — never by daemon type or implementation detail.
 
 ### API Groups
 
 | Group | Purpose |
 |-------|---------|
-| `providers.bgp.miloapis.com/v1alpha1` | BGP daemon lifecycle (BGPProvider) |
+| `providers.bgp.miloapis.com/v1alpha1` | BGP agent lifecycle (BGPProvider) |
 | `bgp.miloapis.com/v1alpha1` | BGP speaker config, sessions, advertisements, and policies |
 
 All resources in both groups are **cluster-scoped** because BGP topology spans namespace boundaries.
@@ -41,7 +49,7 @@ The fleet operates three cluster roles. Each role runs a specific subset of cosm
 A point-of-presence cluster. Runs on every edge node.
 
 - Runs **BGPProvider** (auto-bootstrapped by cosmos startup)
-- Runs **BGPInstance** for `underlay` (FRR) and `overlay` (GoBGP)
+- Runs **BGPInstance** for `underlay` and `overlay` planes
 - Receives **BGPPeer** resources propagated from the management cluster via Karmada
 - Runs **BGPAdvertisement** for loopbacks and SRv6 locators
 - Runs **BGPRoutePolicy** for import/export filtering
@@ -50,13 +58,13 @@ A point-of-presence cluster. Runs on every edge node.
 
 A regional infrastructure cluster. Hosts route reflectors.
 
-- Runs **BGPProvider** for the RR daemon instance
+- Runs **BGPProvider** for the RR agent instance
 - Runs **BGPInstance** for the RR speaker (VPNv4/VPNv6)
 - Receives **BGPPeer** resources from the management cluster
 
 ### Management cluster
 
-The central orchestrator. Does not run any BGP daemons.
+The central orchestrator. Does not run any BGP agents.
 
 - Holds the authoritative **BGPExternalPeer** registry (ToR switches, upstream peers)
 - Writes **BGPPeer** resources and propagates them to POP and infra clusters via Karmada
@@ -80,53 +88,45 @@ There are exactly 6 CRDs across the two API groups.
 
 ### BGPProvider
 
-`BGPProvider` represents a single BGP daemon instance (FRR or GoBGP) running on a node. It is **auto-bootstrapped at cosmos startup** — operators do not create BGPProvider resources manually.
+`BGPProvider` represents one remote BGP agent instance that cosmos connects to
+via gRPC. It is **auto-bootstrapped at cosmos startup** — operators do not create
+BGPProvider resources manually.
 
-The provider is the anchor for all other resources: BGPInstance, BGPPeer, BGPAdvertisement, and BGPRoutePolicy all select a provider via `providerRef` or `providerSelector`.
+The provider is the anchor for all other resources: BGPInstance, BGPPeer,
+BGPAdvertisement, and BGPRoutePolicy all select a provider via `providerRef` or
+`providerSelector`.
 
 #### Spec
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
-| `type` | `string` | Yes | Daemon type. Enum: `FRR`, `GoBGP`. Must match the set daemon block. |
-| `frr` | `FRRConfig` | Conditional | Required when `type` is `FRR`. Mutually exclusive with `gobgp`. |
-| `gobgp` | `GoBGPConfig` | Conditional | Required when `type` is `GoBGP`. Mutually exclusive with `frr`. |
-
-**FRRConfig**
-
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `endpoint` | `string` | No | gRPC endpoint of the FRR management daemon. Default: `localhost:50051`. Must be a loopback address. |
-
-**GoBGPConfig**
-
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `endpoint` | `string` | No | gRPC endpoint of the GoBGP daemon. Default: `localhost:50051`. Must be a loopback address. |
+| `type` | `string` | No | Free-form label identifying the agent implementation. Informational only; cosmos does not interpret this value. |
+| `endpoint` | `string` | No | gRPC address of the remote BGP agent. Default: `localhost:50051`. |
 
 #### Status
 
 | Field | Type | Description |
 |-------|------|-------------|
 | `conditions` | `[]metav1.Condition` | Current state. See conditions table below. |
-| `capabilities` | `ProviderCapabilities` | Address families supported, route reflection support, BFD support. |
+| `capabilities` | `ProviderCapabilities` | Address families supported, route reflection support, BFD support. Populated from the agent's response at reconcile time. |
 | `resolvedEndpoint` | `string` | The gRPC endpoint that was validated and connected. |
-| `daemon` | `string` | The daemon type as confirmed by the health check (`FRR` or `GoBGP`). |
+| `daemon` | `string` | Reflects `spec.type` — the agent type label set at bootstrap time. |
 
 **ProviderCapabilities**
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `addressFamilies` | `[]AddressFamilyCapability` | AFI/SAFI combinations supported by this daemon. |
-| `routeReflection` | `bool` | Whether the daemon supports route reflector operation. |
-| `bfd` | `bool` | Whether the daemon supports BFD. |
+| `addressFamilies` | `[]AddressFamilyCapability` | AFI/SAFI combinations supported by this agent. |
+| `routeReflection` | `bool` | Whether the agent supports route reflector operation. |
+| `bfd` | `bool` | Whether the agent supports BFD. |
 
 **BGPProvider Conditions**
 
 | Type | Meaning |
 |------|---------|
-| `Ready` | `True` when the daemon is reachable and healthy. `False` when the daemon is unreachable or returned an error on the health check. |
-| `RemoteProviderNotSupported` | Set when `endpoint` is not a loopback address. Cosmos only supports local daemon connections. |
+| `Ready` | `True` when the remote agent is reachable and responsive on `spec.endpoint`. `False` when the connection fails or the health probe returns an error. |
+| `InvalidEndpoint` | Set when `spec.endpoint` is absent or malformed. |
+| `DeletionBlocked` | Set when deletion is blocked because a BGPInstance, BGPPeer, BGPAdvertisement, or BGPRoutePolicy still selects this provider. |
 
 #### Example
 
@@ -136,9 +136,12 @@ See [`pop-bgpprovider-auto.yaml`](../examples/pop-bgpprovider-auto.yaml).
 
 ### BGPInstance
 
-`BGPInstance` declares the BGP speaker configuration for a daemon: the local AS, router ID, address families, optional BGP timers, and best-path settings. One BGPInstance is created per plane per node (one for underlay FRR, one for overlay GoBGP).
+`BGPInstance` declares the BGP speaker configuration for an agent: the local AS,
+router ID, address families, optional BGP timers, and best-path settings. One
+BGPInstance is created per plane per node.
 
-When `routeReflector` is set, the instance configures the daemon as a route reflector for the specified cluster ID. This field is only valid in infra clusters.
+When `routeReflector` is set, the instance configures the agent as a route
+reflector for the specified cluster ID. This field is only valid in infra clusters.
 
 #### Spec
 
@@ -192,7 +195,7 @@ When `routeReflector` is set, the instance configures the daemon as a route refl
 
 | Type | Meaning |
 |------|---------|
-| `Ready` | `True` when the speaker has been configured in the daemon with the spec AS, router ID, and address families. |
+| `Ready` | `True` when the speaker has been configured in the agent with the spec AS, router ID, and address families. |
 | `RouteReflectorInPOPCluster` | Set when `spec.routeReflector` is present on a POP cluster node. Route reflection is not supported in POP clusters. |
 
 #### Examples
@@ -205,9 +208,11 @@ See [`pop-bgpinstance-underlay.yaml`](../examples/pop-bgpinstance-underlay.yaml)
 
 ### BGPPeer
 
-`BGPPeer` represents one side of a configured BGP session within a daemon. BGPPeer resources are created directly — operators write them in the management cluster and Karmada propagates them to POP and infra clusters.
+`BGPPeer` represents one side of a configured BGP session within an agent.
+BGPPeer resources are created directly — operators write them in the management
+cluster and Karmada propagates them to POP and infra clusters.
 
-Each BGPPeer is reconciled by the PeerReconciler, which calls `AddPeer`/`UpdatePeer`/`DeletePeer` on the daemon.
+Each BGPPeer is reconciled by the PeerReconciler, which calls `AddPeer`/`UpdatePeer`/`DeletePeer` on the agent.
 
 #### Spec
 
@@ -221,7 +226,7 @@ Each BGPPeer is reconciled by the PeerReconciler, which calls `AddPeer`/`UpdateP
 | `addressFamilies` | `[]AddressFamily` | No | Address families to negotiate. If absent, inherited from the referenced BGPInstance. |
 | `timers` | `BGPPeerTimers` | No | Per-peer timer overrides. |
 | `allowAsIn` | `*int32` | No | Number of times the peer's AS is allowed in received AS paths. Range: 1–10. |
-| `routeReflectorClient` | `bool` | No | When `true`, the daemon treats this peer as a route reflector client. |
+| `routeReflectorClient` | `bool` | No | When `true`, the agent treats this peer as a route reflector client. |
 | `passive` | `bool` | No | Enables passive mode — do not initiate the TCP connection. Default: false. |
 | `ebgpMultihop` | `*int32` | No | eBGP multihop TTL. Range: 1–255. Mutually exclusive with `ttlSecurity`. Invalid on iBGP sessions. |
 | `ttlSecurity` | `*int32` | No | GTSM minimum expected TTL for incoming eBGP packets. Range: 1–254. Mutually exclusive with `ebgpMultihop`. |
@@ -253,22 +258,26 @@ Each BGPPeer is reconciled by the PeerReconciler, which calls `AddPeer`/`UpdateP
 
 | Type | Meaning |
 |------|---------|
-| `Configured` | `True` when the peer has been successfully registered in the daemon via `AddPeer`/`UpdatePeer`. |
+| `Configured` | `True` when the peer has been successfully registered in the agent via `AddPeer`/`UpdatePeer`. |
 | `SessionEstablished` | `True` when the BGP FSM for this peer is in `Established` state. Refreshed on a polling interval. |
 
 ---
 
 ### BGPAdvertisement
 
-`BGPAdvertisement` declares infrastructure prefixes to inject into the BGP RIB. Typical uses are loopback addresses and SRv6 locator blocks. The AdvertisementReconciler calls `AddPath` on the daemon; on deletion it calls `DeletePath`.
+`BGPAdvertisement` declares infrastructure prefixes to inject into the BGP RIB.
+Typical uses are loopback addresses and SRv6 locator blocks. The
+AdvertisementReconciler calls `AddPath` on the agent; on deletion it calls
+`DeletePath`.
 
-BGPAdvertisement targets the **underlay FRR** plane for IPv6 unicast prefixes. VPN address families are not supported on this resource.
+BGPAdvertisement targets providers with Unicast address families. VPN address
+families are not supported on this resource.
 
 #### Spec
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
-| `instanceRef` | `string` | Yes | Name of the BGPInstance to advertise through. Must reference an instance bound to FRR providers with Unicast families. |
+| `instanceRef` | `string` | Yes | Name of the BGPInstance to advertise through. Must reference an instance bound to providers with Unicast address families. |
 | `prefixes` | `[]string` | Yes | IPv4 or IPv6 unicast CIDR prefixes to advertise. Minimum 1. |
 | `peerSelector` | `metav1.LabelSelector` | No | Restricts advertisement to matched BGPPeer resources. If absent, advertise to all peers on matched providers. |
 
@@ -283,16 +292,20 @@ BGPAdvertisement targets the **underlay FRR** plane for IPv6 unicast prefixes. V
 
 | Type | Meaning |
 |------|---------|
-| `Advertised` | `True` when all prefixes have been injected into the daemon RIB. |
+| `Advertised` | `True` when all prefixes have been injected into the agent RIB. |
 | `UnsupportedAddressFamily` | Set when the referenced instance's address family is not supported (e.g., VPN SAFI). |
 
 ---
 
 ### BGPRoutePolicy
 
-`BGPRoutePolicy` declares import and/or export filtering rules for a BGP instance. The RoutePolicyReconciler applies defined sets and policies via the daemon's policy API. Statements within each direction are evaluated in order; the first match wins.
+`BGPRoutePolicy` declares import and/or export filtering rules for a BGP instance.
+The RoutePolicyReconciler applies defined sets and policies via the agent's policy
+API. Statements within each direction are evaluated in order; the first match wins.
 
-Multiple BGPRoutePolicy resources can apply to the same instance and peer set. They are evaluated in descending `priority` order; equal-priority policies are sorted by `metadata.name` ascending.
+Multiple BGPRoutePolicy resources can apply to the same instance and peer set.
+They are evaluated in descending `priority` order; equal-priority policies are
+sorted by `metadata.name` ascending.
 
 #### Spec
 
@@ -347,13 +360,16 @@ Multiple BGPRoutePolicy resources can apply to the same instance and peer set. T
 
 | Type | Meaning |
 |------|---------|
-| `Applied` | `True` when the policy has been installed in the daemon policy table. |
+| `Applied` | `True` when the policy has been installed in the agent policy table. |
 
 ---
 
 ### BGPExternalPeer
 
-`BGPExternalPeer` is the registry of BGP peers that exist outside the cosmos fleet: top-of-rack switches, upstream transit routers, and other external devices. Resources live in the management cluster only and are never propagated to POP or infra clusters.
+`BGPExternalPeer` is the registry of BGP peers that exist outside the cosmos
+fleet: top-of-rack switches, upstream transit routers, and other external devices.
+Resources live in the management cluster only and are never propagated to POP or
+infra clusters.
 
 #### Spec
 
@@ -377,32 +393,47 @@ See [`mgmt-bgpexternalpeer-tor.yaml`](../examples/mgmt-bgpexternalpeer-tor.yaml)
 
 ## 4. Design Principles
 
-**Provider abstraction.** All reconciliation is mediated through BGPProvider. Controllers never talk to a daemon directly — they reconcile through the provider API. This allows FRR and GoBGP to be driven by the same controller logic with different backends.
+**Provider abstraction.** All reconciliation is mediated through BGPProvider.
+Controllers never talk to an agent directly — they reconcile through the provider
+interface. Any BGP agent that implements `BGPProviderService` can be used; cosmos
+drives all of them identically.
 
-**Labels drive dispatch.** Controllers select providers, instances, and peers using `metav1.LabelSelector`. This makes topology configuration declarative and allows dynamic reassignment by changing labels.
+**Labels drive dispatch.** Controllers select providers, instances, and peers
+using `metav1.LabelSelector`. This makes topology configuration declarative and
+allows dynamic reassignment by changing labels.
 
-**Per-provider status.** BGPInstance, BGPPeer, BGPAdvertisement, and BGPRoutePolicy each carry a `providers` list in their status. If a selector matches multiple providers (e.g., on a multi-daemon node), each provider's reconciliation state is tracked independently.
+**Per-provider status.** BGPInstance, BGPPeer, BGPAdvertisement, and
+BGPRoutePolicy each carry a `providers` list in their status. If a selector
+matches multiple providers (e.g., on a multi-plane node), each provider's
+reconciliation state is tracked independently.
 
-**Management cluster as source of truth.** BGPPeer and BGPExternalPeer live authoritatively in the management cluster. Karmada propagates BGPPeer resources to target clusters. The management cluster never runs BGP daemons.
+**Management cluster as source of truth.** BGPPeer and BGPExternalPeer live
+authoritatively in the management cluster. Karmada propagates BGPPeer resources
+to target clusters. The management cluster never runs BGP agents.
 
-**Daemon lifecycle separation.** The BGPProvider auto-bootstrap at cosmos startup is separate from the reconciliation controllers. Providers are always present before any BGPInstance or BGPPeer reconciliation begins.
+**Agent lifecycle separation.** The BGPProvider auto-bootstrap at cosmos startup
+is separate from the reconciliation controllers. Providers are always present
+before any BGPInstance or BGPPeer reconciliation begins.
 
 ---
 
-## 5. Operational Contract — GoBGP API Ownership
+## 5. Provider Ownership
 
-When a CNI plugin and cosmos both interact with the GoBGP daemon on the same node, the following ownership boundaries apply. Violating these boundaries will cause reconciliation conflicts or session disruption.
+When a CNI plugin and cosmos both send calls to the same remote agent, the
+following ownership boundaries apply. Violating these boundaries will cause
+reconciliation conflicts or session disruption.
 
-| GoBGP API surface | Owner |
+| API surface | Owner |
 |---|---|
-| `StartBgp`, speaker config | Cosmos exclusively |
-| `AddPeer` / `UpdatePeer` / `DeletePeer` | Cosmos exclusively |
-| `AddPolicy` / `AddDefinedSet` and all route policy | Cosmos exclusively |
-| `AddVrf` / `DeleteVrf` | CNI exclusively |
-| `AddPath` / `DeletePath` | CNI exclusively |
-| `ListPeer` / `ListPath` (read-only) | Either |
+| Speaker config (AS, router ID, address families) | Cosmos exclusively |
+| Peer add / update / delete | Cosmos exclusively |
+| Route policy add / update / delete | Cosmos exclusively |
+| VRF add / delete | CNI exclusively |
+| Path add / delete for tenant routes | CNI exclusively |
+| Read-only queries (peer list, path list) | Either |
 
-Cosmos does not manage VRF instances or tenant path injection. The CNI plugin manages VRF lifecycle independently of cosmos.
+Cosmos does not manage VRF instances or tenant path injection. The CNI plugin
+manages VRF lifecycle independently of cosmos.
 
 ---
 
@@ -414,9 +445,13 @@ All resources in both API groups carry the finalizer:
 cosmos.bgp.miloapis.com/cleanup
 ```
 
-The cleanup finalizer ensures that daemon state is removed before the Kubernetes object is deleted. The reconciler removes daemon state (peers, policies, advertisements), then removes the finalizer.
+The cleanup finalizer ensures that agent state is removed before the Kubernetes
+object is deleted. The reconciler removes agent state (peers, policies,
+advertisements), then removes the finalizer.
 
-A resource stuck in `Terminating` state means the cleanup finalizer has not been removed. This can happen when the controller is not running, the daemon is unreachable, or a dependency check is blocking deletion.
+A resource stuck in `Terminating` state means the cleanup finalizer has not been
+removed. This can happen when the controller is not running, the agent is
+unreachable, or a dependency check is blocking deletion.
 
 **To force-remove a stuck resource (destructive):**
 
@@ -424,15 +459,22 @@ A resource stuck in `Terminating` state means the cleanup finalizer has not been
 kubectl patch <kind>/<name> --type=merge -p '{"metadata":{"finalizers":[]}}'
 ```
 
-> **Warning:** Forcing finalizer removal bypasses daemon cleanup. Any peers, policies, or routes the resource managed will remain in the daemon until the next full reconciliation or daemon restart. Use this only when the daemon state is already known to be gone (e.g., daemon was rebuilt) or when you are intentionally abandoning orphaned daemon state.
+> **Warning:** Forcing finalizer removal bypasses agent cleanup. Any peers,
+> policies, or routes the resource managed will remain in the agent until the
+> next full reconciliation or agent restart. Use this only when the agent state
+> is already known to be gone (e.g., agent was rebuilt) or when you are
+> intentionally abandoning orphaned agent state.
 
 ### Dependency-blocked deletion
 
 Some resources block deletion until their dependents are removed:
 
-- **BGPProvider**: deletion is blocked if any BGPInstance, BGPPeer, BGPAdvertisement, or BGPRoutePolicy still selects this provider. Remove those resources first.
+- **BGPProvider**: deletion is blocked if any BGPInstance, BGPPeer,
+  BGPAdvertisement, or BGPRoutePolicy still selects this provider. Remove those
+  resources first.
 
-The `DeletionBlocked` condition is set on the resource to indicate which dependency is preventing deletion.
+The `DeletionBlocked` condition is set on the resource to indicate which
+dependency is preventing deletion.
 
 ---
 
@@ -442,23 +484,27 @@ Resources use one of two status layouts depending on their scope.
 
 ### Per-provider status
 
-Resources that are reconciled against one or more daemon instances carry a `providers` list in their status. Each entry has a `providerName` key and a `conditions` array for that provider. The entry also carries a `daemon` field (the daemon type) and an optional `resolvedConfig` field (the configuration actually applied).
+Resources that are reconciled against one or more agent instances carry a
+`providers` list in their status. Each entry has a `providerName` key and a
+`conditions` array for that provider. The entry also carries a `daemon` field
+(the agent type from `spec.type`) and an optional `resolvedConfig` field (the
+configuration actually applied).
 
 This applies to: **BGPInstance**, **BGPPeer**, **BGPAdvertisement**, **BGPRoutePolicy**.
 
 ```yaml
 status:
   providers:
-    - providerName: node-1-frr
-      daemon: FRR
+    - providerName: node-1-underlay
+      daemon: underlay
       conditions:
         - type: Ready
           status: "True"
           reason: Configured
           message: "Speaker configured with AS 65000"
           lastTransitionTime: "2024-01-01T00:00:00Z"
-    - providerName: node-2-frr
-      daemon: FRR
+    - providerName: node-2-underlay
+      daemon: underlay
       conditions:
         - type: Ready
           status: "False"
@@ -471,7 +517,8 @@ If `providerRef` is used instead of `providerSelector`, the list will contain ex
 
 ### Flat status
 
-Resources that are not reconciled against a daemon, or that represent single objects, carry a flat `conditions` array.
+Resources that are not reconciled against an agent, or that represent single
+objects, carry a flat `conditions` array.
 
 This applies to: **BGPProvider**, **BGPExternalPeer**.
 
@@ -481,7 +528,7 @@ status:
     - type: Ready
       status: "True"
       reason: DaemonResponsive
-      message: "FRR daemon is reachable"
+      message: "Remote BGP agent is reachable"
       lastTransitionTime: "2024-01-01T00:00:00Z"
 ```
 
@@ -489,12 +536,14 @@ status:
 
 ## 8. Metrics
 
-Operational counters for BGP sessions are exposed as Prometheus metrics rather than CRD status fields. This avoids high-frequency status writes and eliminates multi-writer races in DaemonSet deployments.
+Operational counters for BGP sessions are exposed as Prometheus metrics rather
+than CRD status fields. This avoids high-frequency status writes and eliminates
+multi-writer races in DaemonSet deployments.
 
 | Metric | Labels | Description |
 |--------|--------|-------------|
 | `bgp_advertised_prefixes_total` | `advertisement` | Prefixes advertised per BGPAdvertisement. |
-| `bgp_route_policies_applied` | `policy` | 1 if the policy is applied to the daemon, 0 otherwise. |
+| `bgp_route_policies_applied` | `policy` | 1 if the policy is applied to the provider, 0 otherwise. |
 
 Metrics are scraped from each cosmos controller pod on `:8082/metrics`.
 

--- a/docs/enhancements/bgp-community-api.md
+++ b/docs/enhancements/bgp-community-api.md
@@ -503,10 +503,10 @@ this section is retained for historical context on the original design intent.
 - `BGPAdvertisement`: the existing advertisement reconciler is extended
   to resolve `communityRefs`, `communitySelector`, and any
   `BGPCommunityAttachment` union into the community list it sends into
-  GoBGP at render time.
+  the provider at render time.
 - `BGPRoutePolicy`: the policy reconciler resolves communities at the
   same point it resolves `prefixSet` today, and translates
-  `communityMatch` + `setCommunities` into the GoBGP policy API.
+  `communityMatch` + `setCommunities` into the provider policy API.
 
 ### RBAC split
 
@@ -608,7 +608,7 @@ CRDs; label selectors cover the same ground declaratively.
    desirable in v1, or should mutation be deferred to a follow-up to
    keep `BGPRoutePolicy` filter-only? Leaning toward shipping it:
    stripping classification at the border is a concrete, already-named
-   user story, and GoBGP supports it natively.
+   user story, and the provider interface supports it.
 2. **Extended communities in v1 vs. with `BGPVPN`.** Route-target
    values are the main user of extended communities, and that user is
    VPN import/export. One option is to gate `type: Extended` until the

--- a/docs/examples/infra-bgpinstance-rr.yaml
+++ b/docs/examples/infra-bgpinstance-rr.yaml
@@ -16,7 +16,6 @@ spec:
   providerSelector:
     matchLabels:
       bgp.datum.net/role: rr-apac
-      bgp.miloapis.com/daemon: frr
   asNumber: 65000
   addressFamilies:
     - afi: IPv4

--- a/docs/examples/pop-bgpinstance-overlay.yaml
+++ b/docs/examples/pop-bgpinstance-overlay.yaml
@@ -1,12 +1,11 @@
-# BGPInstance for the GoBGP overlay plane on a POP node.
+# BGPInstance for the overlay plane on a POP node.
 #
-# This instance configures GoBGP as a VPNv4/VPNv6 BGP speaker for the overlay
-# plane. The overlay plane distributes L3VPN routes for tenant workloads over
-# the underlay fabric.
+# This instance configures the overlay BGP agent as a VPNv4/VPNv6 speaker for
+# the overlay plane. The overlay plane distributes L3VPN routes for tenant
+# workloads over the underlay fabric.
 #
-# The CNI plugin manages VRF lifecycle (AddVrf/DeleteVrf) and path injection
-# (AddPath/DeletePath) on this GoBGP instance independently of cosmos.
-# See the Operational Contract in docs/api/README.md for ownership boundaries.
+# The CNI plugin manages VRF lifecycle and path injection on the overlay provider
+# independently of cosmos. See the API ownership section in docs/api/bgp.md.
 apiVersion: bgp.miloapis.com/v1alpha1
 kind: BGPInstance
 metadata:
@@ -15,7 +14,6 @@ spec:
   providerSelector:
     matchLabels:
       bgp.datum.net/plane: overlay
-      bgp.miloapis.com/daemon: gobgp
   asNumber: 65000
   addressFamilies:
     - afi: IPv4

--- a/docs/examples/pop-bgpinstance-underlay.yaml
+++ b/docs/examples/pop-bgpinstance-underlay.yaml
@@ -1,9 +1,9 @@
-# BGPInstance for the FRR underlay plane on a POP node.
+# BGPInstance for the underlay plane on a POP node.
 #
-# This instance configures the FRR daemon as an IPv6 unicast BGP speaker.
+# This instance configures the underlay BGP agent as an IPv6 unicast speaker.
 # The underlay plane provides fabric routing between nodes and ToR switches.
 #
-# providerSelector targets BGPProvider resources with the underlay/frr labels,
+# providerSelector targets BGPProvider resources with the underlay plane label,
 # which cosmos bootstraps on each node at startup.
 apiVersion: bgp.miloapis.com/v1alpha1
 kind: BGPInstance
@@ -13,7 +13,6 @@ spec:
   providerSelector:
     matchLabels:
       bgp.datum.net/plane: underlay
-      bgp.miloapis.com/daemon: frr
   asNumber: 65000
   addressFamilies:
     - afi: IPv6

--- a/docs/examples/pop-bgpprovider-auto.yaml
+++ b/docs/examples/pop-bgpprovider-auto.yaml
@@ -1,31 +1,31 @@
 # Auto-created at cosmos startup. Do not create manually.
 #
-# cosmos bootstraps one BGPProvider per daemon instance on each node. The labels
-# on this resource drive selection by BGPInstance, BGPPeer, BGPAdvertisement, and
-# BGPRoutePolicy resources via providerSelector.
+# cosmos bootstraps one BGPProvider per remote BGP agent on each node. The
+# labels on this resource drive selection by BGPInstance, BGPPeer,
+# BGPAdvertisement, and BGPRoutePolicy resources via providerSelector.
 #
-# This example shows the FRR provider for the underlay plane on node-1 in jp-east-1.
+# This example shows the underlay BGPProvider for node-1 in jp-east-1.
+# The spec.type field is free-form and informational — cosmos does not
+# interpret it. The endpoint points to the remote agent's gRPC server.
 apiVersion: providers.bgp.miloapis.com/v1alpha1
 kind: BGPProvider
 metadata:
-  name: node-1-frr
+  name: node-1-underlay
   labels:
     bgp.datum.net/plane: underlay
     bgp.datum.net/pop: jp-east-1
-    bgp.miloapis.com/daemon: frr
     bgp.miloapis.com/managed-by: cosmos-bootstrap
   annotations:
     bgp.miloapis.com/node: node-1
 spec:
-  type: FRR
-  frr:
-    endpoint: "localhost:50051"
+  type: underlay
+  endpoint: "localhost:50051"
 status:
   conditions:
     - type: Ready
       status: "True"
       reason: DaemonResponsive
-      message: "FRR daemon is reachable"
+      message: "Remote BGP agent is reachable"
       lastTransitionTime: "2024-01-01T00:00:00Z"
   capabilities:
     addressFamilies:
@@ -34,4 +34,4 @@ status:
     routeReflection: true
     bfd: false
   resolvedEndpoint: "localhost:50051"
-  daemon: FRR
+  daemon: underlay

--- a/docs/examples/rejected-configurations.yaml
+++ b/docs/examples/rejected-configurations.yaml
@@ -7,44 +7,25 @@
 # None of these should be applied to a running cluster.
 
 ---
-# INVALID: BGPProvider with both frr and gobgp set — rejected by CEL validation
+# INVALID: BGPProvider with a malformed endpoint — InvalidEndpoint condition
 #
-# A BGPProvider may configure at most one daemon backend. Setting both frr and
-# gobgp in the same spec violates the CEL rule:
-#   (has(self.frr) && !has(self.gobgp)) || (!has(self.frr) && has(self.gobgp))
-# The API server rejects the resource at admission time.
+# cosmos validates that spec.endpoint is a well-formed host:port string.
+# If the endpoint cannot be parsed, the controller sets Ready=False with
+# reason InvalidEndpoint. The resource is accepted by the API but will
+# never become Ready.
 apiVersion: providers.bgp.miloapis.com/v1alpha1
 kind: BGPProvider
 metadata:
-  name: invalid-dual-daemon
+  name: invalid-malformed-endpoint
 spec:
-  type: FRR
-  frr:
-    endpoint: "localhost:50051"
-  gobgp:
-    endpoint: "localhost:50052"   # ERROR: cannot set both frr and gobgp
-
----
-# INVALID: BGPProvider with a non-loopback endpoint — RemoteProviderNotSupported condition
-#
-# cosmos only supports local daemon connections. If the endpoint resolves to a
-# non-loopback address (anything other than localhost or 127.0.0.1/::1), the
-# controller sets the RemoteProviderNotSupported condition and does not attempt
-# to connect. The resource is accepted by the API but will never become Ready.
-apiVersion: providers.bgp.miloapis.com/v1alpha1
-kind: BGPProvider
-metadata:
-  name: invalid-remote-endpoint
-spec:
-  type: GoBGP
-  gobgp:
-    endpoint: "10.0.1.5:50051"   # ERROR: remote address not supported
+  type: overlay
+  endpoint: "not-a-valid-endpoint"  # ERROR: malformed host:port
 # Expected status:
 #   conditions:
-#     - type: RemoteProviderNotSupported
-#       status: "True"
-#       reason: RemoteEndpoint
-#       message: "endpoint must be a loopback address"
+#     - type: Ready
+#       status: "False"
+#       reason: InvalidEndpoint
+#       message: "endpoint \"not-a-valid-endpoint\" is malformed: ..."
 
 ---
 # INVALID: BGPPeer with both ebgpMultihop and ttlSecurity set — rejected by CEL validation
@@ -58,7 +39,7 @@ kind: BGPPeer
 metadata:
   name: invalid-dual-ebgp-option
 spec:
-  providerRef: node-1-frr
+  providerRef: node-1-underlay
   address: "2001:db8:fabric::1"
   asNumber: 65000
   ebgpMultihop: 2
@@ -94,7 +75,7 @@ kind: BGPPeer
 metadata:
   name: invalid-dual-provider-selection
 spec:
-  providerRef: node-1-frr
+  providerRef: node-1-underlay
   providerSelector:                # ERROR: cannot set both providerRef and providerSelector
     matchLabels:
       bgp.datum.net/plane: underlay
@@ -119,7 +100,7 @@ spec:
     - "2001:db8:loopback::/128"
 # Expected status:
 #   providers:
-#     node-1-gobgp:
+#     - providerName: node-1-overlay
 #       conditions:
 #         - type: UnsupportedAddressFamily
 #           status: "True"
@@ -131,7 +112,7 @@ spec:
 # Route reflectors are infra cluster components. Setting spec.routeReflector
 # on a BGPInstance in a POP cluster is a configuration error. The controller
 # sets the RouteReflectorInPOPCluster condition and does not configure RR mode
-# in the daemon.
+# in the remote agent.
 apiVersion: bgp.miloapis.com/v1alpha1
 kind: BGPInstance
 metadata:
@@ -141,7 +122,6 @@ spec:
     matchLabels:
       bgp.datum.net/plane: underlay
       bgp.datum.net/pop: jp-east-1
-      bgp.miloapis.com/daemon: frr
   asNumber: 65000
   addressFamilies:
     - afi: IPv6
@@ -150,7 +130,7 @@ spec:
     clusterID: "10.0.1.1"         # ERROR: routeReflector is not supported in POP clusters
 # Expected status:
 #   providers:
-#     node-1-frr:
+#     - providerName: node-1-underlay
 #       conditions:
 #         - type: RouteReflectorInPOPCluster
 #           status: "True"
@@ -165,20 +145,19 @@ spec:
 #
 # Resolution: delete or update all dependent resources first.
 #
-# To force removal (destructive — orphans daemon state):
-#   kubectl patch bgpprovider/node-1-frr \
+# To force removal (destructive — orphans remote agent state):
+#   kubectl patch bgpprovider/node-1-underlay \
 #     --type=merge -p '{"metadata":{"finalizers":[]}}'
 apiVersion: providers.bgp.miloapis.com/v1alpha1
 kind: BGPProvider
 metadata:
-  name: node-1-frr                 # still selected by BGPInstance/underlay
+  name: node-1-underlay            # still selected by BGPInstance/underlay
   finalizers:
     - cosmos.bgp.miloapis.com/cleanup
   deletionTimestamp: "2024-01-01T12:00:00Z"
 spec:
-  type: FRR
-  frr:
-    endpoint: "localhost:50051"
+  type: underlay
+  endpoint: "localhost:50051"
 # Expected status:
 #   conditions:
 #     - type: DeletionBlocked

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,13 +1,13 @@
 # Getting Started
 
 This guide walks through the minimal resources needed to bring up a POP node
-running both the FRR underlay and GoBGP overlay BGP planes with cosmos.
+with cosmos managing two BGP planes.
 
 By the end of this guide you will have:
 
 - cosmos running on a POP node with auto-bootstrapped BGPProvider resources
-- A BGPInstance for the FRR underlay (IPv6 unicast)
-- A BGPInstance for the GoBGP overlay (VPNv4/VPNv6)
+- A BGPInstance for the underlay plane (IPv6 unicast)
+- A BGPInstance for the overlay plane (VPNv4/VPNv6)
 - A BGPPeer peering the underlay to a top-of-rack switch
 - A BGPPeer peering the overlay to a regional route reflector
 
@@ -62,8 +62,7 @@ kubectl apply -k config/deploy
 ```
 
 This deploys the cosmos controller DaemonSet in the `bgp-system` namespace.
-Each pod manages both the FRR (underlay) and GoBGP (overlay) daemons on the
-node.
+Each pod connects to the remote BGP agents running on its node.
 
 Verify the DaemonSet is running:
 
@@ -76,7 +75,7 @@ kubectl -n bgp-system get pods -l app.kubernetes.io/name=cosmos
 
 ## Step 3: Verify BGPProvider auto-bootstrap
 
-cosmos bootstraps one BGPProvider per daemon at startup. You do not create
+Cosmos bootstraps one BGPProvider per agent at startup. You do not create
 these manually. After the DaemonSet pods become ready, verify that BGPProvider
 resources exist:
 
@@ -84,30 +83,29 @@ resources exist:
 kubectl get bgpproviders
 ```
 
-You should see one provider per daemon per node. The labels identify the plane
-and daemon type:
+You should see one provider per agent per node. The labels identify the plane:
 
 ```
-NAME            TYPE    READY
-node-1-frr      FRR     True
-node-1-gobgp    GoBGP   True
+NAME              TYPE      READY
+node-1-underlay   underlay  True
+node-1-overlay    overlay   True
 ```
 
 If a provider is not ready, check the conditions:
 
 ```bash
-kubectl describe bgpprovider node-1-frr
+kubectl describe bgpprovider node-1-underlay
 ```
 
-The `Ready` condition will indicate whether the daemon is reachable on its
-gRPC endpoint.
+The `Ready` condition will indicate whether the remote agent is reachable on
+its gRPC endpoint.
 
 ---
 
-## Step 4: Create the underlay BGPInstance (FRR)
+## Step 4: Create the underlay BGPInstance
 
-Create a BGPInstance to configure the FRR daemon as the underlay speaker.
-The `providerSelector` targets the auto-bootstrapped FRR provider:
+Create a BGPInstance to configure the underlay agent as the IPv6 unicast speaker.
+The `providerSelector` targets the auto-bootstrapped underlay provider:
 
 ```yaml
 apiVersion: bgp.miloapis.com/v1alpha1
@@ -118,7 +116,6 @@ spec:
   providerSelector:
     matchLabels:
       bgp.datum.net/plane: underlay
-      bgp.miloapis.com/daemon: frr
   asNumber: 65000
   addressFamilies:
     - afi: IPv6
@@ -137,13 +134,13 @@ Verify the instance is reconciled:
 kubectl get bgpinstances underlay -o jsonpath='{.status.providers}'
 ```
 
-The per-provider status should show a `Ready: True` condition for `node-1-frr`.
+The per-provider status should show a `Ready: True` condition for `node-1-underlay`.
 
 ---
 
-## Step 5: Create the overlay BGPInstance (GoBGP)
+## Step 5: Create the overlay BGPInstance
 
-Create a BGPInstance to configure GoBGP as the overlay speaker:
+Create a BGPInstance to configure the overlay agent as the VPNv4/VPNv6 speaker:
 
 ```yaml
 apiVersion: bgp.miloapis.com/v1alpha1
@@ -154,7 +151,6 @@ spec:
   providerSelector:
     matchLabels:
       bgp.datum.net/plane: overlay
-      bgp.miloapis.com/daemon: gobgp
   asNumber: 65000
   addressFamilies:
     - afi: IPv4
@@ -169,10 +165,9 @@ Apply:
 kubectl apply -f overlay-instance.yaml
 ```
 
-> **Note:** The CNI plugin manages VRF instances and path injection on this
-> GoBGP instance independently. Do not use BGPAdvertisement for overlay routes.
-> See the Operational Contract in `docs/api/bgp.md` for the API ownership
-> boundary between cosmos and the CNI plugin.
+> **Note:** The CNI plugin manages VRF instances and path injection on the
+> overlay provider independently of cosmos. Do not use BGPAdvertisement for
+> overlay routes. See the API ownership section in `docs/api/bgp.md`.
 
 ---
 
@@ -194,7 +189,7 @@ spec:
   providerSelector:
     matchLabels:
       bgp.miloapis.com/node: node-1
-      bgp.miloapis.com/daemon: frr
+      bgp.datum.net/plane: underlay
   address: "2001:db8:fabric::1"
   asNumber: 65000
   addressFamilies:
@@ -217,7 +212,6 @@ spec:
     matchLabels:
       bgp.datum.net/plane: overlay
       bgp.datum.net/pop: jp-east-1
-      bgp.miloapis.com/daemon: gobgp
   address: "2001:db8::rr-apac-1"
   asNumber: 65000
   addressFamilies:
@@ -238,7 +232,7 @@ kubectl --context management apply -f overlay-peer.yaml
 ```
 
 Karmada propagates the BGPPeer resources to the POP cluster and the
-PeerReconciler configures the daemons.
+PeerReconciler configures the remote agents.
 
 ---
 
@@ -261,7 +255,7 @@ The per-provider `SessionEstablished` condition shows whether the BGP FSM
 has reached Established state. If a session is not establishing:
 
 1. Verify network reachability between the node and the peer address
-2. Check that FRR/GoBGP is listening on the expected port
+2. Check that the remote agent is listening on the expected port
 3. Inspect the cosmos controller logs:
    ```bash
    kubectl -n bgp-system logs -l app.kubernetes.io/name=cosmos
@@ -302,7 +296,7 @@ kubectl get bgpadvertisement node-1-loopback -o jsonpath='{.status.providers}'
 ```
 
 The `Advertised: True` condition in the per-provider status confirms the prefix
-is in the FRR RIB.
+is in the remote agent's RIB.
 
 ---
 
@@ -313,13 +307,12 @@ is in the FRR RIB.
   CNI plugin.
 - Review the [example files](examples/) for complete annotated YAML:
   - [BGPProvider (auto-bootstrapped)](examples/pop-bgpprovider-auto.yaml)
-  - [BGPInstance — underlay FRR](examples/pop-bgpinstance-underlay.yaml)
-  - [BGPInstance — overlay GoBGP](examples/pop-bgpinstance-overlay.yaml)
+  - [BGPInstance — underlay](examples/pop-bgpinstance-underlay.yaml)
+  - [BGPInstance — overlay](examples/pop-bgpinstance-overlay.yaml)
   - [BGPInstance — infra route reflector](examples/infra-bgpinstance-rr.yaml)
   - [BGPExternalPeer — ToR switch](examples/mgmt-bgpexternalpeer-tor.yaml)
   - [Rejected configurations](examples/rejected-configurations.yaml)
 
 <!-- References -->
 [bgp]: https://datatracker.ietf.org/doc/html/rfc4271
-[gobgp]: https://github.com/osrg/gobgp
-[frr]: https://frrouting.org/
+[grpc]: https://grpc.io/

--- a/internal/controller/advertisement_reconciler.go
+++ b/internal/controller/advertisement_reconciler.go
@@ -34,7 +34,7 @@ type AdvertisementReconciler struct {
 
 // nodeFinalizer returns the finalizer name for this controller instance.
 // When running as a DaemonSet (NodeName set), each pod uses a node-scoped
-// finalizer so every pod can independently clean up its own GoBGP providers
+// finalizer so every pod can independently clean up its own provider state
 // before the object is fully deleted. Falls back to the shared Finalizer in
 // dev/test mode (NodeName empty).
 func (r *AdvertisementReconciler) nodeFinalizer() string {
@@ -250,7 +250,7 @@ func (r *AdvertisementReconciler) setAdvCondition(
 
 // handleDelete withdraws all prefixes on each local provider and removes this
 // pod's node-scoped finalizer. Each DaemonSet pod independently cleans up its
-// own GoBGP providers; the BGPAdvertisement object is not fully deleted until
+// own provider state; the BGPAdvertisement object is not fully deleted until
 // every node's finalizer has been removed.
 func (r *AdvertisementReconciler) handleDelete(ctx context.Context, adv *bgpv1alpha1.BGPAdvertisement) error {
 	fin := r.nodeFinalizer()

--- a/internal/controller/instance_reconciler.go
+++ b/internal/controller/instance_reconciler.go
@@ -165,9 +165,9 @@ func (r *InstanceReconciler) reconcileForProvider(
 			"ConfigurationFailed", fmt.Sprintf("ConfigureSpeaker: %v", err))
 	}
 
-	// When the speaker was restarted (e.g. GoBGP StopBgp/StartBgp), all peer
-	// state is wiped. Bump an annotation on every BGPPeer that targets this
-	// provider so the PeerReconciler re-applies their configuration.
+	// When the remote agent was restarted, all peer state is wiped. Bump an
+	// annotation on every BGPPeer that targets this provider so the
+	// PeerReconciler re-applies their configuration.
 	if restarted {
 		r.invalidatePeersForProvider(ctx, bp.Name)
 	}

--- a/internal/controller/instance_reconciler_test.go
+++ b/internal/controller/instance_reconciler_test.go
@@ -69,16 +69,16 @@ func TestListenPortPassthrough(t *testing.T) {
 					RouterID:       "10.0.0.1",
 					ListenPort:     tc.listenPort,
 					ProviderSelector: metav1.LabelSelector{
-						MatchLabels: map[string]string{"type": "gobgp"},
+						MatchLabels: map[string]string{"type": "test-agent"},
 					},
 				},
 			}
 			bp := &providersv1alpha1.BGPProvider{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:   "test-provider",
-					Labels: map[string]string{"type": "gobgp"},
+					Labels: map[string]string{"type": "test-agent"},
 				},
-				Spec: providersv1alpha1.BGPProviderSpec{Type: "GoBGP"},
+				Spec: providersv1alpha1.BGPProviderSpec{Type: "test-agent"},
 			}
 
 			fakeClient := fake.NewClientBuilder().
@@ -104,8 +104,8 @@ func TestListenPortPassthrough(t *testing.T) {
 	}
 }
 
-// TestListenPortExplicitOverride is preserved for its daemon-type coverage:
-// the port is always sourced from spec.listenPort regardless of daemon type or RR config.
+// TestListenPortExplicitOverride verifies that the listen port is always sourced
+// from spec.listenPort regardless of agent type or RR config.
 func TestListenPortExplicitOverride(t *testing.T) {
 	rrSpec := &bgpv1alpha1.RouteReflectorConfig{ClusterID: "1.0.0.1"}
 	port := int32(1179)
@@ -117,9 +117,9 @@ func TestListenPortExplicitOverride(t *testing.T) {
 		listenPort     *int32
 		wantListenPort int32
 	}{
-		{name: "GoBGP worker", daemonType: "GoBGP", listenPort: &port, wantListenPort: 1179},
-		{name: "GoBGP RR", daemonType: "GoBGP", routeReflector: rrSpec, listenPort: &port, wantListenPort: 1179},
-		{name: "FRR", daemonType: "FRR", listenPort: &port, wantListenPort: 1179},
+		{name: "worker agent", daemonType: "agent-a", listenPort: &port, wantListenPort: 1179},
+		{name: "RR agent", daemonType: "agent-a", routeReflector: rrSpec, listenPort: &port, wantListenPort: 1179},
+		{name: "other agent", daemonType: "agent-b", listenPort: &port, wantListenPort: 1179},
 	}
 
 	for _, tc := range tests {
@@ -186,16 +186,16 @@ func TestSpeakerSpecPropagation(t *testing.T) {
 			RouterIDSource: "Manual",
 			RouterID:       "192.0.2.1",
 			ProviderSelector: metav1.LabelSelector{
-				MatchLabels: map[string]string{"type": "frr"},
+				MatchLabels: map[string]string{"type": "test-agent"},
 			},
 		},
 	}
 	bp := &providersv1alpha1.BGPProvider{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   "test-provider",
-			Labels: map[string]string{"type": "frr"},
+			Labels: map[string]string{"type": "test-agent"},
 		},
-		Spec: providersv1alpha1.BGPProviderSpec{Type: "FRR"},
+		Spec: providersv1alpha1.BGPProviderSpec{Type: "test-agent"},
 	}
 
 	fakeClient := fake.NewClientBuilder().

--- a/internal/controller/metrics.go
+++ b/internal/controller/metrics.go
@@ -19,7 +19,7 @@ var (
 	routePoliciesAppliedGauge = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Name: "bgp_route_policies_applied",
-			Help: "1 if the BGPRoutePolicy is applied to GoBGP, 0 otherwise",
+			Help: "1 if the BGPRoutePolicy is applied to the provider, 0 otherwise",
 		},
 		[]string{"policy"},
 	)

--- a/internal/controller/peer_reconciler.go
+++ b/internal/controller/peer_reconciler.go
@@ -370,7 +370,7 @@ func (r *PeerReconciler) handleDelete(ctx context.Context, peer *bgpv1alpha1.BGP
 	blocked := false
 	for _, bp := range providers {
 		// Skip DeletePeer if another live BGPPeer still owns this (provider, address) pair.
-		// GoBGP holds one session per address; removing it here would break the other peer.
+		// The provider holds one session per address; removing it here would break the other peer.
 		otherExists := false
 		for _, other := range allPeers.Items {
 			if other.Name == peer.Name || !other.DeletionTimestamp.IsZero() {

--- a/internal/controller/peer_reconciler_test.go
+++ b/internal/controller/peer_reconciler_test.go
@@ -61,7 +61,7 @@ func TestPeerReconcilerEVPNAddressFamily(t *testing.T) {
 			Name:   "node-a",
 			Labels: map[string]string{"role": "vtep"},
 		},
-		Spec: providersv1alpha1.BGPProviderSpec{Type: "FRR"},
+		Spec: providersv1alpha1.BGPProviderSpec{Type: "test-agent"},
 	}
 	bgpPeer := &bgpv1alpha1.BGPPeer{
 		ObjectMeta: metav1.ObjectMeta{Name: "evpn-peer"},
@@ -130,7 +130,7 @@ func TestPeerReconcilerEVPNInheritedFromInstance(t *testing.T) {
 			Name:   "node-a",
 			Labels: map[string]string{"role": "vtep"},
 		},
-		Spec: providersv1alpha1.BGPProviderSpec{Type: "FRR"},
+		Spec: providersv1alpha1.BGPProviderSpec{Type: "test-agent"},
 	}
 	// BGPPeer carries no addressFamilies — must inherit from instance.
 	bgpPeer := &bgpv1alpha1.BGPPeer{

--- a/internal/controller/provider_reconciler.go
+++ b/internal/controller/provider_reconciler.go
@@ -25,7 +25,9 @@ import (
 const (
 	// LabelManagedBy is the label key that records which controller manages a resource.
 	LabelManagedBy = "bgp.miloapis.com/managed-by"
-	// LabelDaemon records which BGP daemon type backs a provider.
+	// LabelDaemon is a conventional label key for tagging BGPProvider resources
+	// by agent type. Cosmos does not interpret its value; it is used by operators
+	// to drive providerSelector matching.
 	LabelDaemon = "bgp.miloapis.com/daemon"
 	// LabelNode records the Kubernetes node name a provider runs on.
 	LabelNode = "bgp.miloapis.com/node"

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -25,11 +25,8 @@ import (
 // after a daemon restart without first querying existing state.
 type Provider interface {
 	// ConfigureSpeaker applies BGPInstance-level configuration. Idempotent.
-	// On daemons that require a restart to change AS or router-ID (e.g. GoBGP
-	// StartBgp/StopBgp), the implementation is responsible for detecting the
-	// change and performing the restart transparently.
-	// Returns (true, nil) when the daemon was restarted; peers must be re-applied
-	// by the caller because a restart wipes all session state.
+	// Returns (true, nil) when the remote agent was restarted; peers must be
+	// re-applied by the caller because a restart wipes all session state.
 	ConfigureSpeaker(ctx context.Context, spec SpeakerSpec) (restarted bool, err error)
 
 	// AddOrUpdatePeer configures a BGP session. Idempotent.
@@ -50,9 +47,7 @@ type Provider interface {
 	// DeletePolicy removes a route policy. Idempotent.
 	DeletePolicy(ctx context.Context, policyName string) error
 
-	// Ready returns nil if the daemon is reachable and responsive.
-	// Implementations should use a lightweight probe (e.g. GetBgp for GoBGP,
-	// a gRPC health check for FRR) rather than establishing a new connection.
+	// Ready returns nil if the remote agent is reachable and responsive.
 	Ready(ctx context.Context) error
 
 	// Capabilities returns the provider's capability set.
@@ -73,9 +68,6 @@ type AddressFamily struct {
 type SpeakerSpec struct {
 	ASNumber int64
 	RouterID string
-	// ListenPort is 179 for FRR (standard BGP port). For GoBGP, it is 1790 on the
-	// route reflector and -1 (listener disabled) on worker nodes, which only connect
-	// outbound to the RR.
 	ListenPort     int32
 	Families       []AddressFamily
 	Timers         TimerConfig

--- a/test/e2e/fixtures/bgpproviders.yaml
+++ b/test/e2e/fixtures/bgpproviders.yaml
@@ -1,32 +1,29 @@
 apiVersion: providers.bgp.miloapis.com/v1alpha1
 kind: BGPProvider
 metadata:
-  name: bgp-e2e-worker-gobgp
+  name: bgp-e2e-worker
   labels:
     bgp.miloapis.com/node: bgp-e2e-worker
-    bgp.miloapis.com/daemon: GoBGP
 spec:
-  type: GoBGP
+  type: test-agent
   endpoint: "localhost:50051"
 ---
 apiVersion: providers.bgp.miloapis.com/v1alpha1
 kind: BGPProvider
 metadata:
-  name: bgp-e2e-worker2-gobgp
+  name: bgp-e2e-worker2
   labels:
     bgp.miloapis.com/node: bgp-e2e-worker2
-    bgp.miloapis.com/daemon: GoBGP
 spec:
-  type: GoBGP
+  type: test-agent
   endpoint: "localhost:50051"
 ---
 apiVersion: providers.bgp.miloapis.com/v1alpha1
 kind: BGPProvider
 metadata:
-  name: bgp-e2e-worker3-gobgp
+  name: bgp-e2e-worker3
   labels:
     bgp.miloapis.com/node: bgp-e2e-worker3
-    bgp.miloapis.com/daemon: GoBGP
 spec:
-  type: GoBGP
+  type: test-agent
   endpoint: "localhost:50051"

--- a/test/e2e/tests/bgp-advertisement/chainsaw-test.yaml
+++ b/test/e2e/tests/bgp-advertisement/chainsaw-test.yaml
@@ -41,7 +41,6 @@ spec:
                 providerSelector:
                   matchLabels:
                     bgp.miloapis.com/node: bgp-e2e-worker
-                    bgp.miloapis.com/daemon: GoBGP
                 address: "${W2}"
                 asNumber: 65000
                 remotePort: 1790
@@ -63,7 +62,6 @@ spec:
                 providerSelector:
                   matchLabels:
                     bgp.miloapis.com/node: bgp-e2e-worker2
-                    bgp.miloapis.com/daemon: GoBGP
                 address: "${W1}"
                 asNumber: 65000
                 remotePort: 1790

--- a/test/e2e/tests/bgp-peer-remote-port/chainsaw-test.yaml
+++ b/test/e2e/tests/bgp-peer-remote-port/chainsaw-test.yaml
@@ -52,7 +52,6 @@ spec:
                 providerSelector:
                   matchLabels:
                     bgp.miloapis.com/node: bgp-e2e-worker
-                    bgp.miloapis.com/daemon: GoBGP
                 address: "${W2}"
                 asNumber: 65000
                 remotePort: 1790
@@ -68,7 +67,6 @@ spec:
                 providerSelector:
                   matchLabels:
                     bgp.miloapis.com/node: bgp-e2e-worker
-                    bgp.miloapis.com/daemon: GoBGP
                 address: "2001:db8::ffff"
                 asNumber: 65000
               EOF

--- a/test/e2e/tests/bgp-peering/chainsaw-test.yaml
+++ b/test/e2e/tests/bgp-peering/chainsaw-test.yaml
@@ -65,7 +65,6 @@ spec:
                 providerSelector:
                   matchLabels:
                     bgp.miloapis.com/node: bgp-e2e-worker
-                    bgp.miloapis.com/daemon: GoBGP
                 address: "${W2}"
                 asNumber: 65000
                 remotePort: 1790
@@ -87,7 +86,6 @@ spec:
                 providerSelector:
                   matchLabels:
                     bgp.miloapis.com/node: bgp-e2e-worker
-                    bgp.miloapis.com/daemon: GoBGP
                 address: "${W3}"
                 asNumber: 65000
                 remotePort: 1790
@@ -109,7 +107,6 @@ spec:
                 providerSelector:
                   matchLabels:
                     bgp.miloapis.com/node: bgp-e2e-worker2
-                    bgp.miloapis.com/daemon: GoBGP
                 address: "${W1}"
                 asNumber: 65000
                 remotePort: 1790
@@ -131,7 +128,6 @@ spec:
                 providerSelector:
                   matchLabels:
                     bgp.miloapis.com/node: bgp-e2e-worker2
-                    bgp.miloapis.com/daemon: GoBGP
                 address: "${W3}"
                 asNumber: 65000
                 remotePort: 1790
@@ -153,7 +149,6 @@ spec:
                 providerSelector:
                   matchLabels:
                     bgp.miloapis.com/node: bgp-e2e-worker3
-                    bgp.miloapis.com/daemon: GoBGP
                 address: "${W1}"
                 asNumber: 65000
                 remotePort: 1790
@@ -175,7 +170,6 @@ spec:
                 providerSelector:
                   matchLabels:
                     bgp.miloapis.com/node: bgp-e2e-worker3
-                    bgp.miloapis.com/daemon: GoBGP
                 address: "${W2}"
                 asNumber: 65000
                 remotePort: 1790

--- a/test/e2e/tests/bgp-vrf-crd-schema/chainsaw-test.yaml
+++ b/test/e2e/tests/bgp-vrf-crd-schema/chainsaw-test.yaml
@@ -22,7 +22,7 @@ spec:
                 instanceRef: overlay
                 providerSelector:
                   matchLabels:
-                    daemon: GoBGP
+                    plane: overlay
                 routeDistinguisher: "65000:100"
                 importRouteTargets:
                   - value: "65000:100"
@@ -84,7 +84,7 @@ spec:
                 instanceRef: overlay
                 providerSelector:
                   matchLabels:
-                    daemon: GoBGP
+                    plane: overlay
                 routeDistinguisher: "192.0.2.1:100"
                 importRouteTargets:
                   - value: "192.0.2.1:100"
@@ -108,7 +108,7 @@ spec:
                 instanceRef: overlay
                 providerSelector:
                   matchLabels:
-                    daemon: GoBGP
+                    plane: overlay
                 routeDistinguisher: "65000:200"
                 importRouteTargets:
                   - value: "65000:200"
@@ -142,7 +142,7 @@ spec:
                 instanceRef: overlay
                 providerSelector:
                   matchLabels:
-                    daemon: GoBGP
+                    plane: overlay
                 routeDistinguisher: "not-valid"
                 importRouteTargets:
                   - value: "65000:100"
@@ -174,7 +174,7 @@ spec:
                 instanceRef: overlay
                 providerSelector:
                   matchLabels:
-                    daemon: GoBGP
+                    plane: overlay
                 routeDistinguisher: "65000:100"
                 importRouteTargets:
                   - value: "bad-rt"
@@ -206,7 +206,7 @@ spec:
                 instanceRef: overlay
                 providerSelector:
                   matchLabels:
-                    daemon: GoBGP
+                    plane: overlay
                 routeDistinguisher: "65000:100"
                 importRouteTargets: []
                 exportRouteTargets:
@@ -237,7 +237,7 @@ spec:
                 instanceRef: overlay
                 providerSelector:
                   matchLabels:
-                    daemon: GoBGP
+                    plane: overlay
                 routeDistinguisher: "65000:100"
                 importRouteTargets:
                   - value: "65000:100"
@@ -267,7 +267,7 @@ spec:
               spec:
                 providerSelector:
                   matchLabels:
-                    daemon: GoBGP
+                    plane: overlay
                 routeDistinguisher: "65000:100"
                 importRouteTargets:
                   - value: "65000:100"
@@ -299,7 +299,7 @@ spec:
                 instanceRef: overlay
                 providerSelector:
                   matchLabels:
-                    daemon: GoBGP
+                    plane: overlay
                 importRouteTargets:
                   - value: "65000:100"
                 exportRouteTargets:


### PR DESCRIPTION
## Summary

- Cosmos BGP CRDs marshal calls to `BGPProvider`; remote agents implement the provider gRPC interface; cosmos has no built-in knowledge of what daemon runs behind a provider
- All docs, examples, source comments, tests, and e2e fixtures updated to reflect this model — FRR and GoBGP are no longer named anywhere outside the archived design doc
- BGPProvider spec documentation corrected to match the actual API (`type` + `endpoint` only; no `frr`/`gobgp` config blocks)
- "GoBGP API Ownership" section in `docs/api/bgp.md` replaced with daemon-agnostic "Provider Ownership"
- E2E fixtures renamed (no `-gobgp` suffix), `bgp.miloapis.com/daemon` label dropped from test selectors
- Go source comments and test data use generic agent type strings

## Test plan

- [ ] `go build ./...` passes
- [ ] `go test ./api/... ./internal/... ./cmd/...` passes
- [ ] Grep for `gobgp` and `frr` (case-insensitive) across non-archived files returns no results
- [ ] E2E suite (`task test:e2e`) passes with updated fixtures

🤖 Generated with [Claude Code](https://claude.com/claude-code)