### PR TITLE
fix(controller): fall back to IPv4 router ID on IPv4-only nodes

### DIFF
--- a/internal/controller/instance_reconciler.go
+++ b/internal/controller/instance_reconciler.go
@@ -206,31 +206,40 @@ func (r *InstanceReconciler) resolveRouterID(
 		return "", fmt.Errorf("get node %s: %w", nodeName, err)
 	}
 
-	// Collect all IPv6 InternalIP addresses.
-	var ipv6Addrs []string
+	// Collect InternalIP addresses, preferring IPv6 over IPv4.
+	var ipv6Addrs, ipv4Addrs []string
 	for _, addr := range node.Status.Addresses {
 		if addr.Type != corev1.NodeInternalIP {
 			continue
 		}
 		ip := net.ParseIP(addr.Address)
-		if ip == nil || ip.To4() != nil {
-			continue // skip IPv4
+		if ip == nil {
+			continue
 		}
-		ipv6Addrs = append(ipv6Addrs, addr.Address)
+		if ip.To4() != nil {
+			ipv4Addrs = append(ipv4Addrs, addr.Address)
+		} else {
+			ipv6Addrs = append(ipv6Addrs, addr.Address)
+		}
 	}
 
-	if len(ipv6Addrs) == 0 {
-		return "", fmt.Errorf("node %s has no IPv6 InternalIP addresses", nodeName)
+	if len(ipv6Addrs) > 0 {
+		// Prefer IPv6: derive router ID from the last 4 bytes.
+		sort.Strings(ipv6Addrs)
+		selectedIP := net.ParseIP(ipv6Addrs[0])
+		if selectedIP == nil {
+			return "", fmt.Errorf("parse selected IPv6 address %q", ipv6Addrs[0])
+		}
+		return ipv6ToRouterID(selectedIP), nil
 	}
 
-	// Lexicographically first IPv6 address.
-	sort.Strings(ipv6Addrs)
-	selectedIP := net.ParseIP(ipv6Addrs[0])
-	if selectedIP == nil {
-		return "", fmt.Errorf("parse selected IPv6 address %q", ipv6Addrs[0])
+	if len(ipv4Addrs) > 0 {
+		// Fall back to IPv4: the address is already a valid 32-bit router ID.
+		sort.Strings(ipv4Addrs)
+		return ipv4Addrs[0], nil
 	}
 
-	return ipv6ToRouterID(selectedIP), nil
+	return "", fmt.Errorf("node %s has no InternalIP addresses", nodeName)
 }
 
 // writeInstanceProviderStatus writes per-provider status for a BGPInstance using server-side apply.

--- a/internal/controller/instance_reconciler_test.go
+++ b/internal/controller/instance_reconciler_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"testing"
 
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
@@ -219,5 +220,98 @@ func TestSpeakerSpecPropagation(t *testing.T) {
 	}
 	if stub.lastSpec.RouterID != "192.0.2.1" {
 		t.Errorf("RouterID = %q, want %q", stub.lastSpec.RouterID, "192.0.2.1")
+	}
+}
+
+// TestResolveRouterIDAutoSource verifies that resolveRouterID prefers IPv6 when
+// available and falls back to IPv4 for IPv4-only nodes (e.g. Kind without dual-stack).
+func TestResolveRouterIDAutoSource(t *testing.T) {
+	tests := []struct {
+		name      string
+		addresses []corev1.NodeAddress
+		wantID    string
+		wantErr   bool
+	}{
+		{
+			name: "IPv6 only",
+			addresses: []corev1.NodeAddress{
+				{Type: corev1.NodeInternalIP, Address: "fd00::1"},
+			},
+			wantID: "0.0.0.1",
+		},
+		{
+			name: "IPv4 only fallback",
+			addresses: []corev1.NodeAddress{
+				{Type: corev1.NodeInternalIP, Address: "10.0.0.5"},
+			},
+			wantID: "10.0.0.5",
+		},
+		{
+			name: "dual-stack prefers IPv6",
+			addresses: []corev1.NodeAddress{
+				{Type: corev1.NodeInternalIP, Address: "10.0.0.5"},
+				{Type: corev1.NodeInternalIP, Address: "fd00::1"},
+			},
+			wantID: "0.0.0.1",
+		},
+		{
+			name: "no InternalIP addresses",
+			addresses: []corev1.NodeAddress{
+				{Type: corev1.NodeExternalIP, Address: "1.2.3.4"},
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			node := &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-node"},
+				Status:     corev1.NodeStatus{Addresses: tc.addresses},
+			}
+			bp := &providersv1alpha1.BGPProvider{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:   "test-provider",
+					Labels: map[string]string{LabelNode: "test-node"},
+				},
+				Spec: providersv1alpha1.BGPProviderSpec{Type: "test-agent"},
+			}
+			instance := &bgpv1alpha1.BGPInstance{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-instance"},
+				Spec: bgpv1alpha1.BGPInstanceSpec{
+					ASNumber:       64512,
+					RouterIDSource: "Auto",
+					ProviderSelector: metav1.LabelSelector{
+						MatchLabels: map[string]string{LabelNode: "test-node"},
+					},
+				},
+			}
+
+			fakeClient := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithObjects(instance, bp, node).
+				WithStatusSubresource(instance).
+				Build()
+
+			r := &InstanceReconciler{
+				Client: fakeClient,
+				Scheme: scheme,
+				Pool:   provider.NewPool(),
+			}
+
+			gotID, err := r.resolveRouterID(context.Background(), instance, bp)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got routerID=%q", gotID)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("resolveRouterID: %v", err)
+			}
+			if gotID != tc.wantID {
+				t.Errorf("routerID = %q, want %q", gotID, tc.wantID)
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Summary

- `resolveRouterID` (Auto mode) previously required an IPv6 `InternalIP` and returned an error on IPv4-only nodes (e.g. Kind clusters without dual-stack enabled)
- Now prefers IPv6 when available, falls back to the lexicographically first IPv4 `InternalIP` — which is already a valid 32-bit BGP router ID with no conversion
- Adds `TestResolveRouterIDAutoSource` covering IPv6-only, IPv4-only fallback, dual-stack (IPv6 wins), and no-addresses error cases

## Test plan

- [ ] `go build ./...` passes
- [ ] `go test ./...` passes including new `TestResolveRouterIDAutoSource` subtests
- [ ] Verify on a Kind cluster (IPv4-only) that a `BGPInstance` with `routerIDSource: Auto` reconciles successfully and uses the node's IPv4 address as the router ID

🤖 Generated with [Claude Code](https://claude.com/claude-code)