### PR TITLE
fix(api): use int64 for ASN fields to fix invalid OpenAPI v3 schema

### DIFF
--- a/api/bgp/v1alpha1/peer_types.go
+++ b/api/bgp/v1alpha1/peer_types.go
@@ -43,7 +43,7 @@ type BGPPeerSpec struct {
 	// +kubebuilder:validation:Required
 	// +kubebuilder:validation:Minimum=1
 	// +kubebuilder:validation:Maximum=4294967295
-	PeerASN uint32 `json:"peerASN"`
+	PeerASN int64 `json:"peerASN"`
 
 	// Address is the remote peer's IPv4 or IPv6 address.
 	// +kubebuilder:validation:Required

--- a/api/bgp/v1alpha1/peer_types_test.go
+++ b/api/bgp/v1alpha1/peer_types_test.go
@@ -1,0 +1,205 @@
+package v1alpha1
+
+import (
+	"encoding/json"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func newTestPeer() *BGPPeer {
+	return &BGPPeer{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "bgp.miloapis.com/v1alpha1",
+			Kind:       "BGPPeer",
+		},
+		ObjectMeta: metav1.ObjectMeta{Name: "test-peer"},
+		Spec: BGPPeerSpec{
+			RouterTarget: RouterTarget{
+				RouterRef: &RouterRef{Name: "test-router"},
+			},
+			PeerASN: 65000,
+			Address: "10.0.0.2",
+			AddressFamilies: []AddressFamily{
+				{
+					AFI:  AFIIPv4,
+					SAFI: SAFIUnicast,
+				},
+			},
+		},
+	}
+}
+
+// TestBGPPeerDeepCopy verifies that DeepCopy produces an independent copy.
+func TestBGPPeerDeepCopy(t *testing.T) {
+	orig := newTestPeer()
+	dup := orig.DeepCopy()
+
+	dup.Spec.PeerASN = 65001
+	dup.Spec.Address = "10.0.0.3"
+	dup.Spec.Description = "mutated"
+
+	if orig.Spec.PeerASN != 65000 {
+		t.Errorf("PeerASN mutated: got %d, want 65000", orig.Spec.PeerASN)
+	}
+	if orig.Spec.Address != "10.0.0.2" {
+		t.Errorf("Address mutated: got %q", orig.Spec.Address)
+	}
+	if orig.Spec.Description != "" {
+		t.Errorf("Description mutated: got %q", orig.Spec.Description)
+	}
+}
+
+// TestBGPPeerDeepCopyNil verifies DeepCopy on a nil pointer returns nil.
+func TestBGPPeerDeepCopyNil(t *testing.T) {
+	var p *BGPPeer
+	if p.DeepCopy() != nil {
+		t.Error("DeepCopy on nil pointer should return nil")
+	}
+}
+
+// TestBGPPeerJSONRoundTrip verifies that the struct serialises and
+// deserialises through JSON without data loss.
+func TestBGPPeerJSONRoundTrip(t *testing.T) {
+	orig := newTestPeer()
+	orig.Spec.Description = "spine-1"
+
+	data, err := json.Marshal(orig)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+
+	var got BGPPeer
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+
+	if got.Spec.PeerASN != orig.Spec.PeerASN {
+		t.Errorf("PeerASN: got %d, want %d", got.Spec.PeerASN, orig.Spec.PeerASN)
+	}
+	if got.Spec.Address != orig.Spec.Address {
+		t.Errorf("Address: got %q, want %q", got.Spec.Address, orig.Spec.Address)
+	}
+	if got.Spec.Description != orig.Spec.Description {
+		t.Errorf("Description: got %q, want %q", got.Spec.Description, orig.Spec.Description)
+	}
+}
+
+// TestBGPPeerListDeepCopy verifies that BGPPeerList.DeepCopy produces
+// independent copies of each item.
+func TestBGPPeerListDeepCopy(t *testing.T) {
+	list := &BGPPeerList{
+		Items: []BGPPeer{*newTestPeer()},
+	}
+	copied := list.DeepCopy()
+	copied.Items[0].Spec.PeerASN = 99999
+
+	if list.Items[0].Spec.PeerASN != 65000 {
+		t.Errorf("original list item mutated via copy")
+	}
+}
+
+// TestBGPPeerPeerASNFieldName verifies the JSON key is "peerASN".
+func TestBGPPeerPeerASNFieldName(t *testing.T) {
+	orig := newTestPeer()
+	data, err := json.Marshal(orig.Spec)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+
+	var m map[string]any
+	if err := json.Unmarshal(data, &m); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+
+	raw, ok := m["peerASN"]
+	if !ok {
+		t.Fatal("expected JSON key \"peerASN\" not found")
+	}
+	val, ok := raw.(float64)
+	if !ok {
+		t.Fatalf("expected peerASN to be a number, got %T", raw)
+	}
+	if int64(val) != orig.Spec.PeerASN {
+		t.Errorf("peerASN value: got %v, want %d", val, orig.Spec.PeerASN)
+	}
+}
+
+// TestBGPPeerLargePeerASN verifies that 4-byte ASNs (values above signed int32 max)
+// survive JSON round-trip correctly. This is the regression test for the
+// format: int32 / maximum: 4294967295 schema bug.
+func TestBGPPeerLargePeerASN(t *testing.T) {
+	// Max 4-byte ASN — the boundary of the uint32 range.
+	const maxASN = ^uint32(0) // 4294967295
+
+	peer := &BGPPeer{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "bgp.miloapis.com/v1alpha1",
+			Kind:       "BGPPeer",
+		},
+		ObjectMeta: metav1.ObjectMeta{Name: "large-asn-peer"},
+		Spec: BGPPeerSpec{
+			RouterTarget: RouterTarget{
+				RouterRef: &RouterRef{Name: "test-router"},
+			},
+			PeerASN: int64(maxASN),
+			Address: "10.0.0.2",
+			AddressFamilies: []AddressFamily{
+				{AFI: AFIIPv4, SAFI: SAFIUnicast},
+			},
+		},
+	}
+
+	data, err := json.Marshal(peer)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+
+	var got BGPPeer
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+
+	if got.Spec.PeerASN != int64(maxASN) {
+		t.Errorf("PeerASN after round-trip: got %d, want %d", got.Spec.PeerASN, maxASN)
+	}
+}
+
+// TestBGPPeerPeerASNAboveSignedInt32Max verifies that values > 2^31-1
+// (the signed int32 ceiling) are handled correctly.
+func TestBGPPeerPeerASNAboveSignedInt32Max(t *testing.T) {
+	// 2^31 = 2147483648 — the first value beyond signed int32 range.
+	const aboveSignedMax int64 = 2147483648
+
+	peer := &BGPPeer{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "bgp.miloapis.com/v1alpha1",
+			Kind:       "BGPPeer",
+		},
+		ObjectMeta: metav1.ObjectMeta{Name: "above-int32-peer"},
+		Spec: BGPPeerSpec{
+			RouterTarget: RouterTarget{
+				RouterRef: &RouterRef{Name: "test-router"},
+			},
+			PeerASN: aboveSignedMax,
+			Address: "10.0.0.2",
+			AddressFamilies: []AddressFamily{
+				{AFI: AFIIPv4, SAFI: SAFIUnicast},
+			},
+		},
+	}
+
+	data, err := json.Marshal(peer)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+
+	var got BGPPeer
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+
+	if got.Spec.PeerASN != aboveSignedMax {
+		t.Errorf("PeerASN after round-trip: got %d, want %d", got.Spec.PeerASN, aboveSignedMax)
+	}
+}

--- a/api/bgp/v1alpha1/router_types.go
+++ b/api/bgp/v1alpha1/router_types.go
@@ -51,7 +51,7 @@ type BGPRouterSpec struct {
 	// +kubebuilder:validation:Required
 	// +kubebuilder:validation:Minimum=1
 	// +kubebuilder:validation:Maximum=4294967295
-	LocalASN uint32 `json:"localASN"`
+	LocalASN int64 `json:"localASN"`
 
 	// RouterID is a unique 32-bit identifier expressed in IPv4 dotted-decimal notation.
 	// In an IPv6-only underlay this is a logical identifier only.

--- a/api/bgp/v1alpha1/router_types_test.go
+++ b/api/bgp/v1alpha1/router_types_test.go
@@ -128,3 +128,93 @@ func TestBGPRouterRolesOmitEmpty(t *testing.T) {
 		t.Error("expected \"roles\" key to be absent when empty")
 	}
 }
+
+// TestBGPRouterLargeLocalASN verifies that 4-byte ASNs (values above signed int32 max)
+// survive JSON round-trip correctly. This is the regression test for the
+// format: int32 / maximum: 4294967295 schema bug.
+func TestBGPRouterLargeLocalASN(t *testing.T) {
+	// Max 4-byte ASN — the boundary of the uint32 range.
+	const maxASN = ^uint32(0) // 4294967295
+
+	router := &BGPRouter{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "bgp.miloapis.com/v1alpha1",
+			Kind:       "BGPRouter",
+		},
+		ObjectMeta: metav1.ObjectMeta{Name: "large-asn-router"},
+		Spec: BGPRouterSpec{
+			TargetRef:  TargetRef{Kind: "Node", Name: "node-1"},
+			LocalASN:   int64(maxASN),
+			RouterID:   "10.0.0.1",
+			Roles:      []RouterRole{RouterRoleTransit},
+			AddressFamilies: []AddressFamily{
+				{AFI: AFIIPv4, SAFI: SAFIUnicast},
+			},
+		},
+	}
+
+	data, err := json.Marshal(router)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+
+	var got BGPRouter
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+
+	if got.Spec.LocalASN != int64(maxASN) {
+		t.Errorf("LocalASN after round-trip: got %d, want %d", got.Spec.LocalASN, maxASN)
+	}
+}
+
+// TestBGPRouterLocalASNAboveSignedInt32Max verifies that values > 2^31-1
+// (the signed int32 ceiling) are handled correctly.
+func TestBGPRouterLocalASNAboveSignedInt32Max(t *testing.T) {
+	// 2^31 = 2147483648 — the first value beyond signed int32 range.
+	const aboveSignedMax int64 = 2147483648
+
+	router := &BGPRouter{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "bgp.miloapis.com/v1alpha1",
+			Kind:       "BGPRouter",
+		},
+		ObjectMeta: metav1.ObjectMeta{Name: "above-int32-router"},
+		Spec: BGPRouterSpec{
+			TargetRef:  TargetRef{Kind: "Node", Name: "node-1"},
+			LocalASN:   aboveSignedMax,
+			RouterID:   "10.0.0.1",
+			Roles:      []RouterRole{RouterRoleTransit},
+			AddressFamilies: []AddressFamily{
+				{AFI: AFIIPv4, SAFI: SAFIUnicast},
+			},
+		},
+	}
+
+	data, err := json.Marshal(router)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+
+	var got BGPRouter
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+
+	if got.Spec.LocalASN != aboveSignedMax {
+		t.Errorf("LocalASN after round-trip: got %d, want %d", got.Spec.LocalASN, aboveSignedMax)
+	}
+}
+
+// TestBGPRouterDeepCopyLocalASN verifies that mutating LocalASN on the copy
+// does not affect the original.
+func TestBGPRouterDeepCopyLocalASN(t *testing.T) {
+	orig := newTestRouter()
+	orig.Spec.LocalASN = 654321
+	dup := orig.DeepCopy()
+
+	dup.Spec.LocalASN = 999999
+	if orig.Spec.LocalASN != 654321 {
+		t.Errorf("LocalASN mutated: got %d, want 654321", orig.Spec.LocalASN)
+	}
+}

--- a/config/crd/bgp.miloapis.com_bgppeers.yaml
+++ b/config/crd/bgp.miloapis.com_bgppeers.yaml
@@ -131,7 +131,7 @@ spec:
                 type: string
               peerASN:
                 description: PeerASN is the remote AS number.
-                format: int32
+                format: int64
                 maximum: 4294967295
                 minimum: 1
                 type: integer

--- a/config/crd/bgp.miloapis.com_bgprouters.yaml
+++ b/config/crd/bgp.miloapis.com_bgprouters.yaml
@@ -102,7 +102,7 @@ spec:
                 description: |-
                   LocalASN is the BGP Autonomous System Number for this router.
                   Must be a valid 2-byte or 4-byte ASN per RFC 6793.
-                format: int32
+                format: int64
                 maximum: 4294967295
                 minimum: 1
                 type: integer


### PR DESCRIPTION
## Problem

BGPRouter/BGPPeer CRDs had an invalid OpenAPI v3 schema: `format: int32` with `maximum: 4294967295`. Since OpenAPI v3 `format: int32` constrains to signed 32-bit (-2147483648 to 2147483647), the max exceeded the format range, causing Kubernetes to reject **all** BGPPeer/BGPRouter creations.

## Fix

- `router_types.go`: `LocalASN uint32` → `LocalASN int64`
- `peer_types.go`: `PeerASN uint32` → `PeerASN int64`
- Updated CRD YAMLs: `format: int32` → `format: int64`

`format: int64` supports values up to 9223372036854775807 — well above the 4294967295 max ASN.

## Tests

- `TestBGPRouterLargeLocalASN` — max 4-byte ASN (4294967295) round-trip
- `TestBGPRouterLocalASNAboveSignedInt32Max` — value 2147483648 round-trip
- `TestBGPRouterDeepCopyLocalASN` — DeepCopy independence
- `TestBGPPeerLargePeerASN` — max 4-byte ASN round-trip
- `TestBGPPeerPeerASNAboveSignedInt32Max` — value 2147483648 round-trip
- `TestBGPPeerDeepCopy`, `TestBGPPeerDeepCopyNil`, `TestBGPPeerJSONRoundTrip`, `TestBGPPeerListDeepCopy`, `TestBGPPeerPeerASNFieldName` — missing BGPPeer parity tests

## Checklist

- [x] Code changes pass `go test ./...`
- [x] CRD schema corrected for both BGPRouter and BGPPeer
- [x] Regression tests added for large 4-byte ASN values