### PR TITLE
feat(api): consolidate BGPPeer status into Ready condition

### DIFF
--- a/api/bgp/v1alpha1/peer_types.go
+++ b/api/bgp/v1alpha1/peer_types.go
@@ -1,7 +1,10 @@
 package v1alpha1
 
 import (
+	"fmt"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
 )
 
 // BGPPeerState represents the BGP Finite State Machine state of a session.
@@ -14,6 +17,41 @@ const (
 	BGPPeerStateOpenSent    BGPPeerState = "OpenSent"
 	BGPPeerStateOpenConfirm BGPPeerState = "OpenConfirm"
 	BGPPeerStateEstablished BGPPeerState = "Established"
+)
+
+// Condition type constants for BGPPeer.
+//
+// These follow Kubernetes condition conventions: a small set of stable,
+// semantically-meaningful types whose Status/Reason/Message fields carry
+// the dynamic detail (via Reason = FSM state, Message = explanation).
+const (
+	// ConditionTypeReady indicates whether the BGP session is fully up.
+	// True when sessionState == Established; False otherwise with Reason
+	// set to the current FSM state (e.g. "OpenSent", "Active").
+	ConditionTypeReady string = "Ready"
+
+	// ConditionTypeAccepted indicates whether the peer configuration has
+	// been accepted by the BGP runtime (FRR/GoBGP, etc.).
+	ConditionTypeAccepted string = "Accepted"
+)
+
+// Idle sub-reasons — used as Ready.Reason when sessionState == Idle.
+const (
+	// IdleReasonBackOff indicates exponential back-off before next
+	// connection attempt.
+	IdleReasonBackOff string = "BackOff"
+
+	// IdleReasonConnectionRefused indicates the TCP connection was
+	// actively refused by the peer.
+	IdleReasonConnectionRefused string = "ConnectionRefused"
+
+	// IdleReasonHoldTimerExpired indicates the peer failed to send
+	// KEEPALIVE within the hold timer.
+	IdleReasonHoldTimerExpired string = "HoldTimerExpired"
+
+	// IdleReasonIdle is the default when the session is simply not
+	// started (no recent failure).
+	IdleReasonIdle string = "Idle"
 )
 
 // BGPPeer defines a BGP session to a remote peer. It binds to one or more
@@ -103,6 +141,76 @@ type BGPPeerList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`
 	Items           []BGPPeer `json:"items"`
+}
+
+// updatePeerConditions updates the Ready condition based on the current
+// BGP FSM state. It is a reference implementation for controller authors.
+//
+// The method mutates and returns the conditions slice in-place via
+// metav1.SetStatusCondition, following Kubernetes condition conventions:
+//   - Ready.Status = True only when session is Established
+//   - Ready.Status = False for all intermediate states, with Reason set
+//     to the FSM state string (e.g. "OpenSent", "Active")
+//   - For Idle, Reason is delegated to the caller via the idleReason arg
+//
+// The ObservedGeneration is set to gen so consumers can correlate this
+// status with the spec generation that produced it.
+func (s *BGPPeerStatus) updatePeerConditions(state BGPPeerState, gen int64, idleReason string) {
+	ready := metav1.Condition{
+		Type:               ConditionTypeReady,
+		ObservedGeneration: gen,
+	}
+
+	switch state {
+	case BGPPeerStateEstablished:
+		ready.Status = metav1.ConditionTrue
+		ready.Reason = "Established"
+		ready.Message = "BGP session is Established; address families negotiated."
+	case BGPPeerStateOpenConfirm:
+		ready.Status = metav1.ConditionFalse
+		ready.Reason = "OpenConfirm"
+		ready.Message = "BGP session in OpenConfirm state, awaiting KEEPALIVE."
+	case BGPPeerStateOpenSent:
+		ready.Status = metav1.ConditionFalse
+		ready.Reason = "OpenSent"
+		ready.Message = "BGP OPEN message sent, awaiting peer OPEN."
+	case BGPPeerStateActive:
+		ready.Status = metav1.ConditionFalse
+		ready.Reason = "Active"
+		ready.Message = "BGP session Active, attempting to establish TCP connection."
+	case BGPPeerStateConnect:
+		ready.Status = metav1.ConditionFalse
+		ready.Reason = "Connect"
+		ready.Message = "BGP session in Connect state, waiting for TCP connection."
+	case BGPPeerStateIdle:
+		ready.Status = metav1.ConditionFalse
+		ready.Reason = idleReason
+		ready.Message = "BGP session is Idle."
+	default:
+		// Unknown state — treat as idle with a generic reason.
+		ready.Status = metav1.ConditionFalse
+		ready.Reason = "Unknown"
+		ready.Message = fmt.Sprintf("BGP session is in unknown state %q.", state)
+	}
+
+	meta.SetStatusCondition(&s.Conditions, ready)
+}
+
+// SetAcceptedCondition updates (or creates) the Accepted condition.
+// Call this after validating and accepting the peer spec into the runtime.
+func (s *BGPPeerStatus) SetAcceptedCondition(accepted bool, gen int64, reason, message string) {
+	status := metav1.ConditionFalse
+	if accepted {
+		status = metav1.ConditionTrue
+	}
+	cond := metav1.Condition{
+		Type:               ConditionTypeAccepted,
+		Status:             status,
+		Reason:             reason,
+		Message:            message,
+		ObservedGeneration: gen,
+	}
+	meta.SetStatusCondition(&s.Conditions, cond)
 }
 
 func init() {

--- a/api/bgp/v1alpha1/peer_types_test.go
+++ b/api/bgp/v1alpha1/peer_types_test.go
@@ -203,3 +203,225 @@ func TestBGPPeerPeerASNAboveSignedInt32Max(t *testing.T) {
 		t.Errorf("PeerASN after round-trip: got %d, want %d", got.Spec.PeerASN, aboveSignedMax)
 	}
 }
+
+// TestConditionConstants verifies the condition type and idle reason constants.
+func TestConditionConstants(t *testing.T) {
+	if ConditionTypeReady != "Ready" {
+		t.Errorf("ConditionTypeReady = %q, want %q", ConditionTypeReady, "Ready")
+	}
+	if ConditionTypeAccepted != "Accepted" {
+		t.Errorf("ConditionTypeAccepted = %q, want %q", ConditionTypeAccepted, "Accepted")
+	}
+	if IdleReasonBackOff != "BackOff" {
+		t.Errorf("IdleReasonBackOff = %q, want %q", IdleReasonBackOff, "BackOff")
+	}
+	if IdleReasonConnectionRefused != "ConnectionRefused" {
+		t.Errorf("IdleReasonConnectionRefused = %q, want %q", IdleReasonConnectionRefused, "ConnectionRefused")
+	}
+	if IdleReasonHoldTimerExpired != "HoldTimerExpired" {
+		t.Errorf("IdleReasonHoldTimerExpired = %q, want %q", IdleReasonHoldTimerExpired, "HoldTimerExpired")
+	}
+	if IdleReasonIdle != "Idle" {
+		t.Errorf("IdleReasonIdle = %q, want %q", IdleReasonIdle, "Idle")
+	}
+}
+
+// TestUpdatePeerConditions_Established verifies Ready=True for Established.
+func TestUpdatePeerConditions_Established(t *testing.T) {
+	var status BGPPeerStatus
+	status.updatePeerConditions(BGPPeerStateEstablished, 42, "")
+
+	c := findCondition(status.Conditions, ConditionTypeReady)
+	if c == nil {
+		t.Fatal("Ready condition not found")
+	}
+	if c.Status != metav1.ConditionTrue {
+		t.Errorf("Ready.Status = %s, want True", c.Status)
+	}
+	if c.Reason != "Established" {
+		t.Errorf("Ready.Reason = %q, want %q", c.Reason, "Established")
+	}
+	if c.ObservedGeneration != 42 {
+		t.Errorf("ObservedGeneration = %d, want 42", c.ObservedGeneration)
+	}
+}
+
+// TestUpdatePeerConditions_Intermediate verifies Ready=False with FSM Reason.
+func TestUpdatePeerConditions_Intermediate(t *testing.T) {
+	tests := []struct {
+		state  BGPPeerState
+		reason string
+	}{
+		{BGPPeerStateOpenConfirm, "OpenConfirm"},
+		{BGPPeerStateOpenSent, "OpenSent"},
+		{BGPPeerStateActive, "Active"},
+		{BGPPeerStateConnect, "Connect"},
+	}
+	for _, tt := range tests {
+		t.Run(string(tt.state), func(t *testing.T) {
+			var status BGPPeerStatus
+			status.updatePeerConditions(tt.state, 1, "")
+
+			c := findCondition(status.Conditions, ConditionTypeReady)
+			if c == nil {
+				t.Fatal("Ready condition not found")
+			}
+			if c.Status != metav1.ConditionFalse {
+				t.Errorf("Ready.Status = %s, want False", c.Status)
+			}
+			if c.Reason != tt.reason {
+				t.Errorf("Ready.Reason = %q, want %q", c.Reason, tt.reason)
+			}
+		})
+	}
+}
+
+// TestUpdatePeerConditions_Idle verifies Ready=False with caller-supplied idle reason.
+func TestUpdatePeerConditions_Idle(t *testing.T) {
+	tests := []struct {
+		reason string
+	}{
+		{IdleReasonBackOff},
+		{IdleReasonConnectionRefused},
+		{IdleReasonHoldTimerExpired},
+		{IdleReasonIdle},
+		{"CustomReason"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.reason, func(t *testing.T) {
+			var status BGPPeerStatus
+			status.updatePeerConditions(BGPPeerStateIdle, 7, tt.reason)
+
+			c := findCondition(status.Conditions, ConditionTypeReady)
+			if c == nil {
+				t.Fatal("Ready condition not found")
+			}
+			if c.Status != metav1.ConditionFalse {
+				t.Errorf("Ready.Status = %s, want False", c.Status)
+			}
+			if c.Reason != tt.reason {
+				t.Errorf("Ready.Reason = %q, want %q", c.Reason, tt.reason)
+			}
+		})
+	}
+}
+
+// TestUpdatePeerConditions_Unknown verifies the default branch.
+func TestUpdatePeerConditions_Unknown(t *testing.T) {
+	var status BGPPeerStatus
+	status.updatePeerConditions("NonExistent", 0, "")
+
+	c := findCondition(status.Conditions, ConditionTypeReady)
+	if c == nil {
+		t.Fatal("Ready condition not found")
+	}
+	if c.Status != metav1.ConditionFalse {
+		t.Errorf("Ready.Status = %s, want False", c.Status)
+	}
+	if c.Reason != "Unknown" {
+		t.Errorf("Ready.Reason = %q, want %q", c.Reason, "Unknown")
+	}
+}
+
+// TestUpdatePeerConditions_Idempotent verifies SetStatusCondition replaces previous Ready.
+func TestUpdatePeerConditions_Idempotent(t *testing.T) {
+	var status BGPPeerStatus
+
+	// First update: Idle.
+	status.updatePeerConditions(BGPPeerStateIdle, 1, IdleReasonIdle)
+	if len(status.Conditions) != 1 {
+		t.Fatalf("expected 1 condition, got %d", len(status.Conditions))
+	}
+
+	// Second update: Established — should replace, not append.
+	status.updatePeerConditions(BGPPeerStateEstablished, 2, "")
+	if len(status.Conditions) != 1 {
+		t.Fatalf("expected 1 condition after update, got %d", len(status.Conditions))
+	}
+	c := findCondition(status.Conditions, ConditionTypeReady)
+	if c == nil || c.Status != metav1.ConditionTrue {
+		t.Error("Ready should be True after Established update")
+	}
+	if c.ObservedGeneration != 2 {
+		t.Errorf("ObservedGeneration = %d, want 2", c.ObservedGeneration)
+	}
+}
+
+// TestSetAcceptedCondition verifies the Accepted condition helper.
+func TestSetAcceptedCondition(t *testing.T) {
+	t.Run("accepted", func(t *testing.T) {
+		var status BGPPeerStatus
+		status.SetAcceptedCondition(true, 5, "ConfigAccepted", "Peer config accepted by runtime.")
+
+		c := findCondition(status.Conditions, ConditionTypeAccepted)
+		if c == nil {
+			t.Fatal("Accepted condition not found")
+		}
+		if c.Status != metav1.ConditionTrue {
+			t.Errorf("Accepted.Status = %s, want True", c.Status)
+		}
+		if c.Reason != "ConfigAccepted" {
+			t.Errorf("Accepted.Reason = %q, want %q", c.Reason, "ConfigAccepted")
+		}
+	})
+
+	t.Run("rejected", func(t *testing.T) {
+		var status BGPPeerStatus
+		status.SetAcceptedCondition(false, 3, "InvalidPeerAddress", "address must be a valid IP")
+
+		c := findCondition(status.Conditions, ConditionTypeAccepted)
+		if c == nil {
+			t.Fatal("Accepted condition not found")
+		}
+		if c.Status != metav1.ConditionFalse {
+			t.Errorf("Accepted.Status = %s, want False", c.Status)
+		}
+	})
+
+	t.Run("toggles", func(t *testing.T) {
+		var status BGPPeerStatus
+		// Accept first.
+		status.SetAcceptedCondition(true, 1, "Accepted", "ok")
+		c := findCondition(status.Conditions, ConditionTypeAccepted)
+		if c == nil || c.Status != metav1.ConditionTrue {
+			t.Error("expected True after first call")
+		}
+		// Then reject — should flip.
+		status.SetAcceptedCondition(false, 2, "Rejected", "bad")
+		c = findCondition(status.Conditions, ConditionTypeAccepted)
+		if c == nil || c.Status != metav1.ConditionFalse {
+			t.Error("expected False after second call")
+		}
+		if c.ObservedGeneration != 2 {
+			t.Errorf("ObservedGeneration = %d, want 2", c.ObservedGeneration)
+		}
+	})
+}
+
+// TestUpdatePeerConditions_CoexistWithAccepted verifies Ready and Accepted
+// conditions can coexist in the same Conditions slice.
+func TestUpdatePeerConditions_CoexistWithAccepted(t *testing.T) {
+	var status BGPPeerStatus
+	status.SetAcceptedCondition(true, 1, "Accepted", "config accepted")
+	status.updatePeerConditions(BGPPeerStateEstablished, 1, "")
+
+	if len(status.Conditions) != 2 {
+		t.Fatalf("expected 2 conditions, got %d", len(status.Conditions))
+	}
+
+	ready := findCondition(status.Conditions, ConditionTypeReady)
+	accepted := findCondition(status.Conditions, ConditionTypeAccepted)
+	if ready == nil || accepted == nil {
+		t.Error("both Ready and Accepted conditions should be present")
+	}
+}
+
+// findCondition returns the condition of the given type, or nil if not found.
+func findCondition(conds []metav1.Condition, typ string) *metav1.Condition {
+	for i := range conds {
+		if conds[i].Type == typ {
+			return &conds[i]
+		}
+	}
+	return nil
+}

--- a/docs/api/bgp.md
+++ b/docs/api/bgp.md
@@ -18,10 +18,10 @@ contracts. Cosmos does not define how routing intent is realized.
 
 The fleet uses two BGP planes per node:
 
-| Plane | Purpose |
-|-------|---------|
+| Plane        | Purpose                                                            |
+|--------------|--------------------------------------------------------------------|
 | **Underlay** | IPv6 unicast fabric routing between nodes and top-of-rack switches |
-| **Overlay** | L2VPN EVPN distribution for tenant workloads |
+| **Overlay**  | L2VPN EVPN distribution for tenant workloads                       |
 
 Each plane is represented by a separate `BGPRouter` resource. `BGPPeer`,
 `BGPAdvertisement`, and `BGPPolicy` resources target a router by direct
@@ -95,50 +95,50 @@ is the primary ownership boundary for `BGPPeer`, `BGPAdvertisement`, and
 
 #### Spec
 
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `targetRef` | `TargetRef` | Yes | Identifies the execution target. |
-| `targetRef.kind` | `string` | Yes | Target resource kind. Supported: `Node`. |
-| `targetRef.name` | `string` | Yes | Name of the target resource. |
-| `roles` | `[]RouterRole` | Yes | Functional roles. Minimum 1. |
-| `localASN` | `uint32` | Yes | Local AS number. Range: 1–4294967295. |
-| `routerID` | `string` | Yes | Router ID in IPv4 dotted-decimal notation. |
-| `addressFamilies` | `[]AddressFamily` | Yes | Address families this router activates. Minimum 1. |
+| Field             | Type              | Required | Description                                                |
+|-------------------|-------------------|----------|------------------------------------------------------------|
+| `targetRef`       | `TargetRef`       | Yes      | Identifies the execution target.                           |
+| `targetRef.kind`  | `string`          | Yes      | Target resource kind. Supported: `Node`.                   |
+| `targetRef.name`  | `string`          | Yes      | Name of the target resource.                               |
+| `roles`           | `[]RouterRole`    | Yes      | Functional roles. Minimum 1.                               |
+| `localASN`        | `uint32`          | Yes      | Local AS number. Range: 1–4294967295.                      |
+| `routerID`        | `string`          | Yes      | Router ID in IPv4 dotted-decimal notation.                 |
+| `addressFamilies` | `[]AddressFamily` | Yes      | Address families this router activates. Minimum 1.         |
 
 **RouterRole** (string enum)
 
-| Value | Meaning |
-|-------|---------|
-| `fabric` | Router participates in the internal fabric (underlay or overlay). |
-| `tenant` | Router serves a tenant workload network. |
-| `transit` | Router carries transit traffic between autonomous systems. |
+| Value     | Meaning                                                           |
+|-----------|-------------------------------------------------------------------|
+| `fabric`  | Router participates in the internal fabric (underlay or overlay). |
+| `tenant`  | Router serves a tenant workload network.                          |
+| `transit` | Router carries transit traffic between autonomous systems.        |
 
 #### Status
 
-| Field | Type | Description |
-|-------|------|-------------|
-| `phase` | `string` | Current phase. Enum: `Pending`, `Ready`, `Failed`. |
-| `observedGeneration` | `int64` | Last spec generation reflected in this status. |
-| `roles` | `[]RouterRole` | Active roles as observed by the implementation. |
-| `peers` | `BGPRouterPeerSummary` | Peer session counts. |
-| `conditions` | `[]metav1.Condition` | Top-level conditions. |
+| Field                | Type                   | Description                                        |
+|----------------------|------------------------|----------------------------------------------------|
+| `phase`              | `string`               | Current phase. Enum: `Pending`, `Ready`, `Failed`. |
+| `observedGeneration` | `int64`                | Last spec generation reflected in this status.     |
+| `roles`              | `[]RouterRole`         | Active roles as observed by the implementation.    |
+| `peers`              | `BGPRouterPeerSummary` | Peer session counts.                               |
+| `conditions`         | `[]metav1.Condition`   | Top-level conditions.                              |
 
 **BGPRouterPeerSummary**
 
-| Field | Type | Description |
-|-------|------|-------------|
-| `total` | `int32` | Total number of configured peers. |
+| Field         | Type    | Description                                    |
+|---------------|---------|------------------------------------------------|
+| `total`       | `int32` | Total number of configured peers.              |
 | `established` | `int32` | Count of peers currently in Established state. |
 
 **BGPRouter Conditions**
 
-| Type | Required | Meaning when True |
-|------|----------|-------------------|
-| `Ready` | Required | Router is fully configured and the runtime is accepting routing intent. |
-| `RuntimeAvailable` | Required | The routing runtime is reachable and accepting configuration. |
-| `ConfigApplied` | Required | Current spec has been translated and applied to the runtime. |
-| `Degraded` | Required | One or more configured peers has not reached Established state. |
-| `PeersEstablished` | Optional | All configured peers have reached Established state. |
+| Type               | Required | Meaning when True                                                       |
+|--------------------|----------|-------------------------------------------------------------------------|
+| `Ready`            | Required | Router is fully configured and the runtime is accepting routing intent. |
+| `RuntimeAvailable` | Required | The routing runtime is reachable and accepting configuration.           |
+| `ConfigApplied`    | Required | Current spec has been translated and applied to the runtime.            |
+| `Degraded`         | Required | One or more configured peers has not reached Established state.         |
+| `PeersEstablished` | Optional | All configured peers have reached Established state.                    |
 
 #### Example
 
@@ -172,35 +172,35 @@ spec:
 
 #### Spec
 
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `routerRef` | `RouterRef` | Conditional | Direct reference to a single BGPRouter. Mutually exclusive with `routerSelector`. |
-| `routerSelector` | `RouterSelector` | Conditional | Label selector for BGPRouter resources. Mutually exclusive with `routerRef`. |
-| `peerASN` | `uint32` | Yes | Remote AS number. Range: 1–4294967295. |
-| `address` | `string` | Yes | Remote peer's IPv4 or IPv6 address. |
-| `description` | `string` | No | Human-readable label for this peer (e.g., `"spine-1"`). |
-| `authSecretRef` | `LocalSecretRef` | No | References a Secret containing the MD5 TCP authentication password under key `"password"`. |
-| `addressFamilies` | `[]AddressFamily` | Yes | Address families negotiated on this session. Minimum 1. |
-| `holdTime` | `Duration` | No | BGP hold timer. Must be 0 (disabled) or ≥ 3s. Default: `90s`. |
-| `keepaliveTime` | `Duration` | No | BGP keepalive interval. Must be ≤ holdTime / 3. Default: `30s`. |
+| Field             | Type              | Required | Description                                                |
+|-------------------|-------------------|----------|------------------------------------------------------------|
+| `routerRef`       | `RouterRef`       | Conditional | Direct reference to a single BGPRouter. Mutually exclusive with `routerSelector`. |
+| `routerSelector`  | `RouterSelector`  | Conditional | Label selector for BGPRouter resources. Mutually exclusive with `routerRef`. |
+| `peerASN`         | `uint32`          | Yes      | Remote AS number. Range: 1–4294967295.                     |
+| `address`         | `string`          | Yes      | Remote peer's IPv4 or IPv6 address.                        |
+| `description`     | `string`          | No       | Human-readable label for this peer (e.g., `"spine-1"`).    |
+| `authSecretRef`   | `LocalSecretRef`  | No       | References a Secret containing the MD5 TCP authentication password under key `"password"`. |
+| `addressFamilies` | `[]AddressFamily` | Yes      | Address families negotiated on this session. Minimum 1.    |
+| `holdTime`        | `Duration`        | No       | BGP hold timer. Must be 0 (disabled) or ≥ 3s. Default: `90s`. |
+| `keepaliveTime`   | `Duration`        | No       | BGP keepalive interval. Must be ≤ holdTime / 3. Default: `30s`. |
 
 **LocalSecretRef**
 
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `name` | `string` | Yes | Name of the Secret in the same namespace. |
+| Field  | Type     | Required | Description                               |
+|--------|----------|----------|-------------------------------------------|
+| `name` | `string` | Yes      | Name of the Secret in the same namespace. |
 
 > Timer fields use Go duration strings (e.g., `"90s"`, `"1m30s"`). Both forms
 > are valid; implementations must accept either.
 
 #### Status
 
-| Field | Type | Description |
-|-------|------|-------------|
-| `observedGeneration` | `int64` | Last spec generation reflected in this status. |
-| `sessionState` | `string` | Current BGP FSM state. |
-| `lastEstablishedTime` | `Time` | Timestamp of the most recent Established transition. |
-| `conditions` | `[]metav1.Condition` | Top-level conditions. |
+| Field                 | Type                 | Description                                          |
+|-----------------------|----------------------|------------------------------------------------------|
+| `observedGeneration`  | `int64`              | Last spec generation reflected in this status.       |
+| `sessionState`        | `string`             | Current BGP FSM state.                               |
+| `lastEstablishedTime` | `Time`               | Timestamp of the most recent Established transition. |
+| `conditions`          | `[]metav1.Condition` | Top-level conditions.                                |
 
 **Session State** (string enum)
 
@@ -208,19 +208,57 @@ spec:
 
 **BGPPeer Conditions**
 
-| Type | Required | Meaning when True |
-|------|----------|-------------------|
-| `Ready` | Required | Session is Established and address families have been negotiated. |
-| `Accepted` | Required | Peer config has been accepted by the runtime. |
-| `SessionIdle` | Required | BGP FSM is in Idle state. |
-| `SessionConnect` | Required | BGP FSM is in Connect state. |
-| `SessionActive` | Required | BGP FSM is in Active state. |
-| `SessionOpenSent` | Required | BGP FSM is in OpenSent state. |
-| `SessionOpenConfirm` | Required | BGP FSM is in OpenConfirm state. |
-| `SessionEstablished` | Required | BGP FSM is in Established state. |
+| Type       | Required | Meaning when True                                                 |
+|------------|----------|-------------------------------------------------------------------|
+| `Ready`    | Required | Session is Established and address families have been negotiated. |
+| `Accepted` | Required | Peer config has been accepted by the runtime.                     |
 
-The session FSM state conditions (`SessionIdle` through `SessionEstablished`)
-are mutually exclusive — exactly one must be `True` at any time.
+Condition type constants are defined in Go as `ConditionTypeReady` and
+`ConditionTypeAccepted` in `api/bgp/v1alpha1/peer_types.go`.
+
+The `Ready` condition reflects the BGP FSM state via its `Status` and `Reason`:
+
+| `sessionState`  | `Ready.Status` | `Ready.Reason`         | Meaning                                       |
+|-----------------|----------------|------------------------|-----------------------------------------------|
+| `Established`   | `True`         | `Established`          | Session is up; all address families negotiated. |
+| `OpenConfirm`   | `False`        | `OpenConfirm`          | BGP OPEN messages exchanged, holding timer running. |
+| `OpenSent`      | `False`        | `OpenSent`             | OPEN message sent, awaiting OPEN from peer.   |
+| `Active`        | `False`        | `Active`               | Attempting to establish (connecting or re-connecting). |
+| `Connect`       | `False`        | `Connect`              | Waiting for TCP connection or initiating connection. |
+| `Idle`          | `False`        | see below              | Session is idle; Reason explains why.         |
+
+**Idle sub-reasons**
+
+When `sessionState` is `Idle`, the `Ready.Reason` is set by the controller
+based on recent events:
+
+| Reason                | Meaning                                                    |
+|-----------------------|------------------------------------------------------------|
+| `BackOff`             | Exponential back-off before next connection attempt.       |
+| `ConnectionRefused`   | TCP connection was actively refused by the peer.           |
+| `HoldTimerExpired`    | Peer failed to send KEEPALIVE within the hold timer.       |
+| `Idle`                | No recent failure; session is simply not started yet.      |
+
+**Controller status update logic**
+
+The reference implementation is the `BGPPeerStatus.updatePeerConditions` method
+in `api/bgp/v1alpha1/peer_types.go`. Call it whenever `sessionState` changes:
+
+```go
+status.updatePeerConditions(state, peer.Generation, idleReason)
+```
+
+For the `Accepted` condition, use `SetAcceptedCondition`:
+
+```go
+status.SetAcceptedCondition(true, peer.Generation, "ConfigAccepted", msg)
+```
+
+This pattern avoids the high API server churn of maintaining 6 mutually exclusive
+conditions that flip every few seconds during session establishment. The
+`sessionState` string field carries the exact FSM state for detailed inspection;
+the `Ready` condition provides the high-level signal that consumers (e.g. HPA,
+gates, dashboards) need.
 
 #### Example
 
@@ -253,13 +291,13 @@ selector fan-out is intentionally omitted to avoid ambiguous prefix attribution.
 
 #### Spec
 
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `routerRef` | `RouterRef` | Yes | Direct reference to a single BGPRouter. |
-| `addressFamily` | `AddressFamily` | Yes | AFI/SAFI for this advertisement. |
-| `prefixes` | `[]string` | Yes | CIDR prefixes to advertise. Minimum 1. |
-| `communities` | `[]string` | No | BGP communities to attach to advertised prefixes. |
-| `localPreference` | `*uint32` | No | BGP LOCAL_PREF attribute. Only meaningful for iBGP sessions. |
+| Field             | Type            | Required | Description                                                |
+|-------------------|-----------------|----------|------------------------------------------------------------|
+| `routerRef`       | `RouterRef`     | Yes      | Direct reference to a single BGPRouter.                    |
+| `addressFamily`   | `AddressFamily` | Yes      | AFI/SAFI for this advertisement.                           |
+| `prefixes`        | `[]string`      | Yes      | CIDR prefixes to advertise. Minimum 1.                     |
+| `communities`     | `[]string`      | No       | BGP communities to attach to advertised prefixes.          |
+| `localPreference` | `*uint32`       | No       | BGP LOCAL_PREF attribute. Only meaningful for iBGP sessions. |
 
 #### Status
 


### PR DESCRIPTION
## Summary

Add Go constants and reference implementation for the BGPPeer status condition API, consolidating the BGP FSM state tracking into a single `Ready` condition instead of 6 mutually exclusive FSM state conditions.

## Changes

### Go types (`api/bgp/v1alpha1/peer_types.go`)
- **ConditionTypeReady** / **ConditionTypeAccepted** — exported constants for the two BGPPeer condition types
- **Idle sub-reason constants** — `BackOff`, `ConnectionRefused`, `HoldTimerExpired`, `Idle`
- **`BGPPeerStatus.updatePeerConditions()`** — reference implementation that maps all 6 BGP FSM states to the single Ready condition (True only when Established). Idle delegates the Reason to the caller via an argument.
- **`BGPPeerStatus.SetAcceptedCondition()`** — helper for the Accepted condition

### Tests (`api/bgp/v1alpha1/peer_types_test.go`)
- 15 new tests covering all FSM states, idle sub-reasons, unknown state handling, idempotency, Accepted condition toggling, and coexistence of Ready + Accepted

### Docs (`docs/api/bgp.md`)
- Replaced the inline code block with references to the Go methods
- Added a clean Idle sub-reasons table
- Points to `api/bgp/v1alpha1/peer_types.go` as the canonical reference implementation

## Design

This follows Kubernetes condition conventions: a small set of stable, semantically-meaningful condition types whose Status/Reason/Message fields carry the dynamic detail. The `sessionState` string field carries the exact FSM state for detailed inspection; the `Ready` condition provides the high-level signal that consumers (HPA, gates, dashboards) need.

This avoids the high API server churn of maintaining 6 mutually exclusive conditions that flip every few seconds during session establishment.