### PR TITLE
docs: add project docs and refactor Taskfile tool deps

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,89 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## What this project is
+
+Cosmos defines Kubernetes CRDs and API types for BGP routing and virtual networking. It is **API-only** — no controllers, no binaries, no runtime. Implementations consume these APIs; this repo just defines the contract.
+
+Module: `go.miloapis.com/cosmos`
+
+## Commands
+
+This project uses [Task](https://taskfile.dev/) (`task`), not `make`.
+
+```bash
+task tools        # Install all dev tools into ./bin/ (run first)
+task build        # go fmt + go vet + go build ./...
+task test:unit    # Run unit tests with coverage (excludes /e2e)
+task test:e2e     # Create kind cluster, deploy CRDs, run Chainsaw tests, teardown
+task lint         # golangci-lint + yamlfmt check
+task lint-fix     # Same with auto-fix applied
+task generate     # Regenerate zz_generated.deepcopy.go files
+task manifests    # Regenerate CRD YAML in config/crd/ from Go types
+task ci           # Full local pipeline: build → lint → test:unit → test:e2e
+task clean        # Remove ./bin/ and cover.out
+```
+
+Run a single unit test package:
+```bash
+GOOS=linux go test ./api/bgp/v1alpha1/... -run TestName -v
+```
+
+All dev tools (golangci-lint, controller-gen, chainsaw, yamlfmt) are installed locally to `./bin/` — they are never installed system-wide.
+
+## Architecture
+
+### API groups
+
+| Group              | Version    | Resources                                                       |
+|--------------------|------------|-----------------------------------------------------------------|
+| `bgp.miloapis.com` | `v1alpha1` | BGPRouter, BGPPeer, BGPAdvertisement, BGPPolicy, BGPVRFInstance |
+| `vpc.miloapis.com` | `v1alpha1` | VPC, VPCAttachment                                              |
+
+Source lives in `api/bgp/v1alpha1/` and `api/vpc/v1alpha1/`. Each resource has its own `*_types.go` file; shared types (RouterTarget, AddressFamily, etc.) live in `shared_types.go`.
+
+### BGP resource ownership model
+
+`BGPRouter` is the ownership boundary — one per routing plane per node. All other BGP resources bind to routers:
+
+- `routerRef` — binds to a single BGPRouter by name (used by BGPPeer, BGPPolicy, BGPAdvertisement)
+- `routerSelector` — binds to multiple BGPRouters by label (used by BGPPeer, BGPPolicy)
+- `BGPAdvertisement` only supports `routerRef` (single-router scope)
+
+The `RouterTarget` struct (in `shared_types.go`) is embedded by resources that support either binding. It carries a CEL validation rule enforcing exactly-one-of.
+
+### Key invariants
+
+- **ASN fields are `int64`** — `int32` produces an invalid OpenAPI v3 schema (max ASN > int32 max). Never use `int32` for ASN.
+- **Kubernetes 1.28+ required** — CEL functions `isIP()` and `isCIDR()` are used for field validation.
+- **Status conditions** follow `metav1.Condition` conventions. Condition type constants (e.g., `ConditionTypeReady`, `ConditionTypeAccepted`) are defined alongside the resource type they belong to.
+- **YAML files must use `.yaml` extension**, never `.yml` — the lint task enforces this.
+
+### Code generation
+
+After changing kubebuilder markers (`// +kubebuilder:...`) or adding new types:
+
+1. `task generate` — regenerates `zz_generated.deepcopy.go`
+2. `task manifests` — regenerates CRDs in `config/crd/`
+
+Both are generated; never edit `zz_generated.deepcopy.go` or CRD YAML directly.
+
+### Testing
+
+Unit tests (`api/**/*_types_test.go`) test validation, defaulting, and marshaling logic. E2E tests use [Chainsaw](https://kyverno.github.io/chainsaw/) against a dual-stack kind cluster (config at `test/e2e/kind-config.yaml`). The e2e suite is driven by `scripts/e2e.sh` and requires Docker.
+
+## Architecture Reference
+
+See [ARCHITECTURE.md](ARCHITECTURE.md) for a full architecture reference including module layout, package roles, resource model, data flow, and known constraints.
+
+## Conventions Reference
+
+See [CONVENTIONS.md](CONVENTIONS.md) for coding standards, naming rules, kubebuilder marker patterns, status condition conventions, and Go-specific conventions.
+
+## Docs
+
+- `docs/api/bgp.md` — full BGP CRD field reference
+- `docs/api/vpc.md` — full VPC CRD field reference
+- `docs/getting-started.md` — install and first resources
+- `docs/enhancements/` — design proposals

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,446 @@
+# Architecture
+
+> Cosmos is a Go module that defines Kubernetes CRDs and API types for BGP routing and virtual networking. It is consumed as a library by external controller implementations; this repository contains no runtime code.
+
+_Last updated: 2026-06-23_
+
+---
+
+## Table of Contents
+
+1. [Overview](#overview)
+2. [Repository Layout](#repository-layout)
+3. [Module / Package Reference](#module--package-reference)
+   - [api/bgp/v1alpha1](#apibgpv1alpha1)
+   - [api/vpc/v1alpha1](#apivpcv1alpha1)
+4. [API Resource Model](#api-resource-model)
+   - [BGP Group](#bgp-group-bgpmiloapis)
+   - [VPC Group](#vpc-group-vpcmiloapis)
+5. [Entry Points](#entry-points)
+6. [Data Flow](#data-flow)
+7. [External Dependencies](#external-dependencies)
+8. [Testing](#testing)
+9. [CI/CD](#cicd)
+10. [Known Constraints & Tech Debt](#known-constraints--tech-debt)
+11. [For Claude](#for-claude)
+
+---
+
+## Overview
+
+Cosmos defines the Kubernetes Custom Resource Definitions (CRDs) and Go API types for two networking domains:
+
+- **BGP routing** (`bgp.miloapis.com`) — abstractions for BGP routers, peers, advertisements, policies, and L2VPN/EVPN VRF instances
+- **Virtual networking** (`vpc.miloapis.com`) — abstractions for virtual private clouds and interface attachments
+
+The module is a **library**, not a binary. External controllers import `go.miloapis.com/cosmos` to register these types with their scheme and reconcile the resources. Cosmos itself ships only the type definitions, validation rules, CRD YAML, and their tests. There are no controllers, no HTTP servers, no goroutines, and no persistent state within this module.
+
+The design follows standard Kubernetes API conventions: resources have a `Spec` (desired state), a `Status` (observed state), and standard `metav1.Condition` conditions. CEL validation rules embedded in kubebuilder markers enforce invariants at the API server level (requiring Kubernetes 1.28+).
+
+---
+
+## Repository Layout
+
+```
+cosmos/
+├── api/
+│   ├── bgp/v1alpha1/          # bgp.miloapis.com/v1alpha1 — 5 CRD types + generated deepcopy
+│   └── vpc/v1alpha1/          # vpc.miloapis.com/v1alpha1 — 2 CRD types + generated deepcopy
+├── config/
+│   ├── crd/                   # Generated CRD YAML (controller-gen output — never edit directly)
+│   └── samples/               # Example resource manifests
+├── docs/
+│   ├── api/                   # Human-readable field reference (bgp.md, vpc.md)
+│   ├── design/                # Design notes
+│   ├── diagrams/              # PlantUML source and rendered diagrams
+│   └── enhancements/          # Design proposals (KEP-style)
+├── hack/
+│   └── boilerplate.go.txt     # Copyright header injected into generated files
+├── scripts/
+│   └── e2e.sh                 # E2E orchestration script (setup → test → teardown)
+├── test/e2e/
+│   ├── chainsaw-config.yaml   # Chainsaw timeouts and cluster name
+│   ├── kind-config.yaml       # kind cluster: 1 control-plane + 3 workers, dual-stack
+│   ├── Taskfile.yaml          # E2E task targets (cluster, Cilium, CRDs, Chainsaw)
+│   ├── fixtures/              # Shared test fixtures (BGPRouter manifests per node)
+│   └── tests/                 # One directory per Chainsaw test scenario
+├── bin/                       # Local dev tool binaries (gitignored)
+├── go.mod                     # Module: go.miloapis.com/cosmos, Go 1.26
+├── go.sum
+├── Taskfile.yaml              # Primary task runner (build, lint, test, generate, manifests)
+├── AGENTS.md                  # CLAUDE.md symlink target — project guidance for Claude Code
+└── CLAUDE.md -> AGENTS.md     # Symlink: CLAUDE.md → AGENTS.md
+```
+
+---
+
+## Module / Package Reference
+
+### api/bgp/v1alpha1
+
+**Purpose:** Defines all Go types, validation rules, and scheme registration for the `bgp.miloapis.com/v1alpha1` API group. Contains five CRD resources and their shared supporting types.
+
+**Key files:**
+
+| File                        | Contents                                                                                                                                                           |
+|-----------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `groupversion_info.go`      | `GroupVersion`, `SchemeBuilder`, `AddToScheme` — scheme registration entry point                                                                                  |
+| `router_types.go`           | `BGPRouter`, `BGPRouterSpec`, `BGPRouterStatus`                                                                                                                   |
+| `peer_types.go`             | `BGPPeer`, `BGPPeerSpec`, `BGPPeerStatus`, condition constants, `updatePeerConditions`, `SetAcceptedCondition`                                                     |
+| `advertisement_types.go`    | `BGPAdvertisement`, `BGPAdvertisementSpec`, `BGPAdvertisementStatus`                                                                                              |
+| `policy_types.go`           | `BGPPolicy`, `BGPPolicySpec`, `BGPPolicyTerm`, `BGPPolicyMatch`, `PolicySetActions`, `CommunitySet`                                                               |
+| `vrf_types.go`              | `BGPVRFInstance`, `BGPVRFInstanceSpec`, `BGPVRFInstanceStatus`, `RouteTarget`                                                                                     |
+| `shared_types.go`           | `RouterTarget`, `RouterRef`, `RouterSelector`, `TargetRef`, `AddressFamily`, `AFI`, `SAFI`, `RouterRole`, `LocalSecretRef`, `RouterStatus`, `ResolvedRouterConfig` |
+| `zz_generated.deepcopy.go`  | Generated `DeepCopy*` methods — do not edit                                                                                                                       |
+
+**External dependencies:**
+- `k8s.io/apimachinery/pkg/apis/meta/v1` — `metav1.TypeMeta`, `metav1.ObjectMeta`, `metav1.Condition`, `metav1.Duration`, `metav1.Time`
+- `k8s.io/apimachinery/pkg/api/meta` — `meta.SetStatusCondition` (used in peer condition helpers)
+- `sigs.k8s.io/controller-runtime/pkg/scheme` — `scheme.Builder` for type registration
+
+**Owns persistent state:** No.
+
+---
+
+### api/vpc/v1alpha1
+
+**Purpose:** Defines all Go types and scheme registration for the `vpc.miloapis.com/v1alpha1` API group. Contains two CRD resources.
+
+**Key files:**
+
+| File                        | Contents                                                                                                                   |
+|-----------------------------|----------------------------------------------------------------------------------------------------------------------------|
+| `groupversion_info.go`      | `GroupVersion`, `SchemeBuilder`, `AddToScheme`                                                                             |
+| `vpc_types.go`              | `VPC`, `VPCSpec`, `VPCStatus`                                                                                              |
+| `vpcattachment_types.go`    | `VPCAttachment`, `VPCAttachmentSpec`, `VPCAttachmentStatus`, `VPCRef`, `VPCAttachmentInterface`, `VPCAttachmentAnnotation` |
+| `zz_generated.deepcopy.go`  | Generated `DeepCopy*` methods — do not edit                                                                                |
+
+**External dependencies:**
+- `k8s.io/apimachinery/pkg/apis/meta/v1` — `metav1.TypeMeta`, `metav1.ObjectMeta`
+- `sigs.k8s.io/controller-runtime/pkg/scheme` — `scheme.Builder`
+
+**Owns persistent state:** No.
+
+---
+
+## API Resource Model
+
+### BGP Group (`bgp.miloapis.com`)
+
+`BGPRouter` is the ownership root. Every other BGP resource binds to one or more routers.
+
+```mermaid
+graph TD
+    Node["Kubernetes Node"]
+    Router["BGPRouter\n(1 per routing plane per node)"]
+    Peer["BGPPeer\n(remote session)"]
+    Adv["BGPAdvertisement\n(prefixes to originate)"]
+    Policy["BGPPolicy\n(import/export rules)"]
+    VRF["BGPVRFInstance\n(L2VPN EVPN VRF)"]
+
+    Node -->|targetRef| Router
+    Router -->|routerRef| Peer
+    Router -->|routerRef| Adv
+    Router -->|routerRef or routerSelector| Policy
+    Router -->|routerRef or routerSelector| VRF
+```
+
+**BGPRouter** — `bgprouters.bgp.miloapis.com`, shortName `bgpr`
+
+One per routing plane per node. Declares the local ASN, router ID, address families, and node binding. Acts as the namespace-scoped ownership boundary for all other BGP resources.
+
+Key spec fields:
+- `targetRef.kind/name` — identifies the Kubernetes Node this router runs on
+- `roles` — one or more of `fabric`, `tenant`, `transit` (at least one required)
+- `localASN int64` — 2-byte or 4-byte BGP ASN (1–4294967295)
+- `routerID string` — IPv4 dotted-decimal notation (logical identifier in IPv6-only underlays)
+- `addressFamilies []AddressFamily` — AFI/SAFI pairs this router activates
+
+Status: `phase` (Pending/Ready/Failed), `observedGeneration`, `peers` (total/established counts), `conditions`.
+
+---
+
+**BGPPeer** — `bgppeers.bgp.miloapis.com`, shortName `bgppr`
+
+A BGP session to a remote peer. Binds to one or more BGPRouters via `routerRef` (single) or `routerSelector` (multi). Exactly one binding must be set — enforced by CEL.
+
+Key spec fields:
+- `RouterTarget` (inline) — `routerRef` or `routerSelector`
+- `peerASN int64` — remote AS number
+- `address string` — remote IPv4 or IPv6 address (CEL: `isIP(self)`)
+- `addressFamilies []AddressFamily` — AFI/SAFI pairs negotiated on this session
+- `holdTime *metav1.Duration` — 0 (disabled) or ≥3s; defaults to 90s
+- `keepaliveTime *metav1.Duration` — must be ≤ holdTime/3; defaults to 30s
+- `authSecretRef *LocalSecretRef` — optional MD5 TCP auth (key: `"password"`)
+
+Status: `sessionState` (BGP FSM state), `lastEstablishedTime`, `observedGeneration`, `conditions`.
+
+Condition constants defined in `peer_types.go`: `ConditionTypeReady`, `ConditionTypeAccepted`. Idle reason constants: `IdleReasonBackOff`, `IdleReasonConnectionRefused`, `IdleReasonHoldTimerExpired`, `IdleReasonIdle`.
+
+Status helper methods (reference implementation for controller authors):
+- `updatePeerConditions(state, gen, idleReason)` — sets Ready condition from FSM state
+- `SetAcceptedCondition(accepted, gen, reason, message)` — sets Accepted condition
+
+---
+
+**BGPAdvertisement** — `bgpadvertisements.bgp.miloapis.com`, shortName `bgpadv`
+
+Prefixes to originate from a single BGPRouter. Intentionally supports only `routerRef` (not `routerSelector`) to avoid ambiguous prefix attribution across multiple routers.
+
+Key spec fields:
+- `routerRef RouterRef` — direct binding to one BGPRouter (required)
+- `addressFamily AddressFamily` — AFI/SAFI for this advertisement
+- `prefixes []string` — 1–256 CIDR prefixes; each validated via CEL `isCIDR()`; `+listType=set`
+- `communities []string` — 0–64 BGP communities in `ASN:NN` or `IP:NN` format
+- `localPreference *uint32` — BGP LOCAL_PREF (iBGP only)
+
+---
+
+**BGPPolicy** — `bgppolicies.bgp.miloapis.com`, shortName `bgpp`
+
+Composable, ordered routing policy applied to a BGPRouter in one direction (import or export). Binds via `routerRef` or `routerSelector`.
+
+Key spec fields:
+- `RouterTarget` (inline)
+- `direction BGPPolicyDirection` — `import` or `export`
+- `terms []BGPPolicyTerm` — 1–32 terms, each with a unique `sequence int32`, a `match`, and an `action` (`permit`/`deny`)
+
+Term match fields: `any bool`, `addressFamilies []AddressFamily`.
+Term set actions (permit only): `communities` (add/remove lists), `localPreference`.
+
+CEL invariants: sequence numbers must be unique; `set` must not be present on `deny` terms.
+
+---
+
+**BGPVRFInstance** — `bgpvrfinstances.bgp.miloapis.com`, shortName `bgpvrf`
+
+Configures an L2VPN EVPN VRF on matched BGPRouters. The targeted BGPRouter must have `l2vpn/evpn` in its `addressFamilies`.
+
+Key spec fields:
+- `RouterTarget` (inline)
+- `routeDistinguisher string` — uniquely identifies the VRF; `ASN:NN` or `IP:NN` format
+- `importRouteTargets []RouteTarget` — 1–32 RT extended communities for route import
+- `exportRouteTargets []RouteTarget` — 1–32 RT extended communities for route export
+
+Status: top-level `conditions`, plus per-router `routers []RouterStatus` (`+listType=map +listMapKey=routerName`). `RouterStatus` holds per-router conditions and a `ResolvedRouterConfig` snapshot.
+
+---
+
+### VPC Group (`vpc.miloapis.com`)
+
+**VPC** — `vpcs.vpc.miloapis.com`
+
+A virtual private cloud defined by CIDR blocks.
+
+Key spec fields:
+- `networks []string` — 1–64 IPv4 or IPv6 CIDRs; validated via CEL `isCIDR()`
+
+Status: `ready bool`, `identifier string`.
+
+---
+
+**VPCAttachment** — `vpcattachments.vpc.miloapis.com`
+
+Attaches a network interface to a VPC.
+
+Key spec fields:
+- `vpc VPCRef` — reference to a VPC by name in the same namespace
+- `interface VPCAttachmentInterface` — interface name and 1–16 IPv4/IPv6 addresses (each validated via CEL `isCIDR()`)
+
+Status: `ready bool`, `identifier string`.
+
+Annotation: `k8s.v1alpha1.vpc.miloapis.com/vpc-attachment` (constant `VPCAttachmentAnnotation`).
+
+---
+
+## Entry Points
+
+This module has no binaries. It is imported by external controllers as a Go library.
+
+To register BGP types with a controller-runtime scheme:
+```go
+import bgpv1alpha1 "go.miloapis.com/cosmos/api/bgp/v1alpha1"
+
+scheme.AddToScheme(bgpv1alpha1.AddToScheme)
+```
+
+To register VPC types:
+```go
+import vpcv1alpha1 "go.miloapis.com/cosmos/api/vpc/v1alpha1"
+
+scheme.AddToScheme(vpcv1alpha1.AddToScheme)
+```
+
+Both `AddToScheme` values are produced by `sigs.k8s.io/controller-runtime/pkg/scheme.Builder` and registered via `init()` in each `*_types.go` file.
+
+---
+
+## Data Flow
+
+There is no runtime data flow within this module. The flow belongs to external controllers that import these types:
+
+```
+User applies YAML manifest
+        │
+        ▼
+Kubernetes API Server
+  validates against CRD schema (CEL rules embedded in config/crd/*.yaml)
+        │
+        ▼
+etcd (resource stored)
+        │
+        ▼
+External controller (watches the API group via controller-runtime)
+  imports go.miloapis.com/cosmos API types to decode resources
+        │
+        ▼
+Controller reconciles: configures underlying BGP daemon (FRR, GoBGP, etc.)
+        │
+        ▼
+Controller writes back .status (sessionState, conditions, observedGeneration)
+```
+
+The CRD YAML in `config/crd/` is the artifact deployed to a cluster. CEL rules in those manifests enforce field-level invariants at admission time (before a resource is stored), independent of any controller.
+
+---
+
+## External Dependencies
+
+| Dependency                        | Version  | Purpose                                                                   |
+|-----------------------------------|----------|---------------------------------------------------------------------------|
+| `k8s.io/api`                      | v0.33.0  | Core Kubernetes API types                                                 |
+| `k8s.io/apimachinery`             | v0.33.0  | `metav1` types, `meta.SetStatusCondition`, scheme/GVK machinery           |
+| `sigs.k8s.io/controller-runtime`  | v0.21.0  | `scheme.Builder` for type registration (only the scheme package is used)  |
+
+All other entries in `go.sum` are transitive dependencies of the above three.
+
+**Dev tooling (local to `./bin/`, not in `go.mod`):**
+
+| Tool              | Version  | Purpose                                                                                |
+|-------------------|----------|----------------------------------------------------------------------------------------|
+| `controller-gen`  | v0.18.0  | Generates `zz_generated.deepcopy.go` and `config/crd/*.yaml` from kubebuilder markers |
+| `golangci-lint`   | v2.1.6   | Go linting                                                                             |
+| `yamlfmt`         | v0.21.0  | YAML formatting; enforces consistent style                                             |
+| `chainsaw`        | v0.2.12  | Kubernetes-native e2e test runner                                                      |
+
+---
+
+## Testing
+
+### Unit tests
+
+- Location: `api/bgp/v1alpha1/*_types_test.go`
+- Framework: stdlib `testing` (no external test framework)
+- Coverage: DeepCopy correctness, JSON round-trip fidelity, JSON field name verification, boundary values (max 4-byte ASN), status condition logic (`updatePeerConditions`, `SetAcceptedCondition`)
+- Run: `GOOS=linux go test ./api/bgp/v1alpha1/... -v`  or `task test:unit`
+
+There are no unit tests for the VPC package (VPC types have no methods beyond generated DeepCopy).
+
+### E2E tests
+
+- Location: `test/e2e/tests/` (one directory per scenario)
+- Framework: [Chainsaw](https://kyverno.github.io/chainsaw/) v0.2.12
+- Cluster: kind cluster `bgp-e2e` with 1 control-plane + 3 worker nodes, dual-stack (`ipFamily: dual`), Cilium CNI
+- Kubernetes version: `kindest/node:v1.34.0`
+
+E2E test scenarios:
+
+| Scenario                   | What it tests                                               |
+|----------------------------|-------------------------------------------------------------|
+| `system-readiness`         | Cluster and CRD readiness after deploy                      |
+| `bgp-peering`              | BGPPeer CRUD, full-mesh IPv6 peer creation across 3 workers |
+| `bgp-peer-timers`          | HoldTime/KeepaliveTime field acceptance                     |
+| `bgp-advertisement`        | BGPAdvertisement resource acceptance and schema validation   |
+| `bgp-policy`               | BGPPolicy resource acceptance                               |
+| `bgp-status-conditions`    | Status condition writes                                     |
+| `bgp-vrf-crd-schema`       | BGPVRFInstance schema validation (RD, RT format)            |
+| `vpc-crd-schema`           | VPC and VPCAttachment schema validation                     |
+
+Chainsaw timeouts: apply=2m, assert=5m, delete=2m, exec=3m.
+
+E2E setup steps (via `scripts/e2e.sh` → `test/e2e/Taskfile.yaml`):
+1. Create kind cluster with dual-stack networking
+2. Install Cilium v1.17.3 (CNI, non-exclusive mode)
+3. Apply all CRDs via `kubectl apply -k config/crd/`
+4. Apply BGPRouter fixtures for each worker node
+5. Run Chainsaw tests (sequential: `--parallel 1`)
+6. Teardown cluster on exit (trap)
+
+Run: `task test:e2e` (requires Docker, kind, kubectl, chainsaw, helm in PATH).
+
+---
+
+## CI/CD
+
+### Pipeline (`.github/workflows/ci.yaml`)
+
+```
+push/PR → main
+      │
+      ├── Build (go fmt + go vet + go build)
+      │         │
+      │    ┌────┴────┐
+      │    │         │
+      │  Test       Lint
+      │  (unit)     (golangci-lint + yamlfmt + .yml check)
+      │    │         │
+      │    └────┬────┘
+      │         │
+      │        E2E
+      │   (kind cluster, 30m timeout)
+```
+
+All jobs use Go 1.26 and cache the Go module download.
+
+### Docker workflow (`.github/workflows/docker.yaml`)
+
+Triggers: after CI succeeds on `main`, or on `v*` tag pushes.
+Registry: `ghcr.io` (GitHub Container Registry).
+Platforms: `linux/amd64`, `linux/arm64`.
+Source: `build/Dockerfile` — **this file does not currently exist in the repository**. The workflow is present but will fail until a Dockerfile is added to `build/`.
+
+### Dependency updates (Renovate)
+
+Renovate runs weekly (Monday before 6am ET). k8s core libraries update monthly. Patch/minor non-k8s Go deps are auto-merged. Major updates require manual review.
+
+---
+
+## Known Constraints & Tech Debt
+
+**No Dockerfile.** The Docker CI workflow (`docker.yaml`) references `build/Dockerfile`, which does not exist. Any attempt to trigger that workflow will fail at the build step.
+
+**BGPAdvertisement has no routerSelector.** This is intentional (documented in code: "Fan-out via routerSelector is intentionally not supported to avoid ambiguous prefix attribution"), but it is an asymmetry from the other BGP resources that operators occasionally find surprising.
+
+**VPC types are less mature.** The VPC package has no unit tests, uses `bool` for status (not `metav1.Condition`), and has commented-out default annotations (`+default:value=false`) that may not work as intended with controller-gen.
+
+**Kubernetes 1.28+ hard requirement.** CEL functions `isIP()` and `isCIDR()` require Kubernetes 1.28+. The CRDs will fail to install on older clusters with a schema validation error. This is not documented in user-facing docs.
+
+**All tools are version-pinned binaries in `./bin/`.** `task tools` must be run before any code generation or linting in a fresh checkout. `go install` is used to install them; there is no lockfile beyond the version suffix in the binary name.
+
+**`CLAUDE.md` is a symlink to `AGENTS.md`.** Both files contain identical content. This is intentional to serve both Claude Code and other AI agents, but can confuse editors and git operations that follow symlinks.
+
+---
+
+## For Claude
+
+**Start here for each concern:**
+
+| Concern                                      | Where to look                                                                                         |
+|----------------------------------------------|-------------------------------------------------------------------------------------------------------|
+| Adding a new CRD                             | `api/bgp/v1alpha1/` — copy an existing `*_types.go`, register in `groupversion_info.go` via `init()` |
+| Understanding a resource's validation rules  | Read the kubebuilder markers in the resource's `*_types.go` file; the CRD YAML is generated from them |
+| Modifying shared types used across resources | `api/bgp/v1alpha1/shared_types.go`                                                                    |
+| Status condition constants                   | Defined in the same file as the resource (e.g., `ConditionTypeReady` is in `peer_types.go`)           |
+| Running tests locally                        | `task test:unit` (unit) or `task test:e2e` (e2e, requires Docker)                                     |
+| Regenerating CRDs after marker changes       | `task generate && task manifests`                                                                      |
+
+**Patterns that differ from Go idioms:**
+- `init()` functions are used extensively to register types with the scheme builder. This is a Kubernetes operator convention, not general Go style.
+- `int64` for ASN fields instead of `uint32` — necessary for valid OpenAPI v3 schema generation.
+- No error returns from type methods — status updates use the Kubernetes condition pattern instead.
+
+**Gotchas:**
+- After any change to `// +kubebuilder:...` markers, both `task generate` and `task manifests` must be run. Forgetting one leaves the code and CRD YAML out of sync.
+- `GOOS=linux` is required when running `go vet` or `go test` locally (the task targets set this). Some types have Linux-specific constraints.
+- `CLAUDE.md` is a symlink. Edit `AGENTS.md` directly; attempts to edit through the symlink will fail.
+- The VRF `BGPVRFInstanceStatus.Routers` field uses `+listType=map +listMapKey=routerName` — different from the standard `+listMapKey=type` used for conditions.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -1,0 +1,363 @@
+# Conventions
+
+> Cosmos is a Go module defining Kubernetes CRDs and API types for BGP routing and virtual networking. It is API-only — no controllers, no runtime code.
+
+_Last updated: 2026-06-23_
+
+---
+
+## Table of Contents
+
+1. [Core Conventions](#core-conventions)
+   - [Naming](#naming)
+   - [Code Organization](#code-organization)
+   - [Comments and Documentation](#comments-and-documentation)
+   - [Testing](#testing)
+   - [Dependencies and Imports](#dependencies-and-imports)
+   - [Git and Version Control](#git-and-version-control)
+2. [Go Conventions](#go-conventions)
+   - [Module and Package Layout](#module-and-package-layout)
+   - [Type Naming](#type-naming)
+   - [kubebuilder Markers](#kubebuilder-markers)
+   - [Status Conditions](#status-conditions)
+   - [Field Types and Invariants](#field-types-and-invariants)
+   - [JSON Serialization](#json-serialization)
+   - [Code Generation](#code-generation)
+   - [Error Handling](#error-handling)
+   - [Testing](#go-testing)
+   - [Linting and Formatting](#linting-and-formatting)
+3. [YAML Conventions](#yaml-conventions)
+4. [Markdown Conventions](#markdown-conventions)
+5. [For Claude](#for-claude)
+
+---
+
+## Core Conventions
+
+### Naming
+
+**Source files** use `snake_case` with a `_types.go` suffix for CRD type definitions:
+
+```
+router_types.go         ← BGPRouter CRD
+peer_types.go           ← BGPPeer CRD
+shared_types.go         ← types shared across resources in the package
+groupversion_info.go    ← scheme registration (fixed name)
+```
+
+**Test files** use `_test.go` suffix adjacent to the file under test:
+
+```
+router_types_test.go    ← tests for router_types.go
+```
+
+**Generated files** use the `zz_generated.` prefix. Never edit them:
+
+```
+zz_generated.deepcopy.go
+```
+
+**Directories** use lowercase kebab-case. The version is part of the path (`v1alpha1`).
+
+### Code Organization
+
+All API types live under `api/<group>/<version>/`. One `_types.go` file per CRD resource. Types shared across resources in the same package live in `shared_types.go`.
+
+```
+api/
+  bgp/v1alpha1/         ← bgp.miloapis.com API group
+  vpc/v1alpha1/         ← vpc.miloapis.com API group
+config/crd/             ← generated CRD YAML — never edit directly
+config/samples/         ← example resources
+docs/api/               ← human-readable field reference
+docs/enhancements/      ← design proposals
+hack/                   ← code generation support files
+scripts/                ← shell scripts (e2e orchestration)
+test/e2e/               ← Chainsaw e2e tests
+bin/                    ← local dev tools (gitignored)
+```
+
+### Comments and Documentation
+
+**Exported types** require a godoc comment that begins with the type name and ends with a period:
+
+```go
+// BGPRouter defines a logical BGP routing context. It abstracts a processing
+// instance bound to a specific execution context.
+type BGPRouter struct { ... }
+```
+
+**Spec and Status types** follow the "defines the desired/observed state of..." convention:
+
+```go
+// BGPRouterSpec defines the desired state of a BGPRouter.
+type BGPRouterSpec struct { ... }
+
+// BGPRouterStatus defines the observed state of a BGPRouter.
+type BGPRouterStatus struct { ... }
+```
+
+**Enum constants** each get a godoc comment:
+
+```go
+// BGPPolicyActionPermit allows the route and optionally applies set actions.
+BGPPolicyActionPermit BGPPolicyAction = "permit"
+```
+
+**Fields** get a single-line comment above them (not end-of-line). The comment is a description; it does not repeat the field name. For fields with kubebuilder markers, the comment precedes the markers:
+
+```go
+// LocalASN is the BGP Autonomous System Number for this router.
+// +kubebuilder:validation:Required
+LocalASN int64 `json:"localASN"`
+```
+
+Do not write comments that explain what the code obviously does. Write them when the WHY is non-obvious — a hidden constraint, a subtle invariant (e.g., the ASN int64 requirement).
+
+### Testing
+
+- Framework: stdlib `testing` only — no testify, no ginkgo.
+- Style: table-driven tests with `t.Run` for multiple cases; single function for unique behaviors.
+- Test function names: `TestTypeName_Behavior` or `TestTypeName` (e.g., `TestBGPPeerDeepCopy`, `TestUpdatePeerConditions_Established`).
+- Helper constructors (e.g., `newTestPeer()`, `newTestRouter()`) are unexported and defined at the top of the test file.
+- Helper lookup functions (e.g., `findCondition`) are pure functions — no `t.Helper()` required.
+- Tests are in the same package as the production code (white-box, not `_test` suffix package).
+- Unit tests cover: DeepCopy correctness, JSON round-trip, field name verification, and boundary values.
+- E2E tests use [Chainsaw](https://kyverno.github.io/chainsaw/) against a live kind cluster. See `test/e2e/`.
+
+### Dependencies and Imports
+
+- `go.sum` is committed; no vendor directory.
+- Imports are grouped in two blocks (gofmt standard): stdlib then external. No blank line between the groups unless there is an internal package.
+- Aliases follow these conventions:
+  - `metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"` — always aliased
+  - `"k8s.io/apimachinery/pkg/api/meta"` — used unaliased
+- No internal packages — all types are exported API surface.
+
+Adding new dependencies: this repo is API-only. New dependencies must have a clear API type requirement (Kubernetes ecosystem only). Do not add runtime or application dependencies.
+
+### Git and Version Control
+
+**Commit messages** follow [Conventional Commits](https://www.conventionalcommits.org/):
+
+```
+type(scope): short imperative description
+
+Optional body explaining the why.
+```
+
+Types in use: `feat`, `fix`, `refactor`, `chore`, `ci`, `style`.
+Scopes in use: `api`, `bgp`, `vpc`, `e2e`, `docs`, `fmt`, `proto`, `controller`.
+
+**Branch naming**: `type/kebab-case-description`
+
+```
+feat/bgp-peer-status-consolidated
+fix/asn-int64-schema
+refactor/bgp-api-v3
+```
+
+**Merge strategy**: merge commits (PRs land as merge commits; no squash or rebase).
+
+---
+
+## Go Conventions
+
+### Module and Package Layout
+
+- Module path: `go.miloapis.com/cosmos`
+- Go version: 1.26
+- Package name equals the directory's last path segment (`v1alpha1`).
+- One package per API group version. All types for `bgp.miloapis.com/v1alpha1` live in `api/bgp/v1alpha1/`; one `_types.go` file per CRD.
+- No `internal/`, `pkg/`, or `cmd/` packages — this is an API-only module.
+
+### Type Naming
+
+| Construct               | Rule                                          | Example                                        |
+|-------------------------|-----------------------------------------------|------------------------------------------------|
+| CRD resource            | `PascalCase` prefixed with group abbreviation | `BGPRouter`, `BGPPeer`, `VPC`                  |
+| Spec                    | `{Resource}Spec`                              | `BGPRouterSpec`                                |
+| Status                  | `{Resource}Status`                            | `BGPRouterStatus`                              |
+| List                    | `{Resource}List`                              | `BGPRouterList`                                |
+| Enum type               | `{Resource}{Field}` or descriptive noun       | `BGPRouterPhase`, `BGPPeerState`               |
+| Enum constant           | `{TypeName}{Value}`                           | `BGPRouterPhasePending`, `RouterRoleFabric`    |
+| Condition type constant | `ConditionType{Name}` (`string`)              | `ConditionTypeReady`, `ConditionTypeAccepted`  |
+| Idle reason constant    | `IdleReason{Name}` (`string`)                 | `IdleReasonBackOff`                            |
+| Shared struct           | Descriptive PascalCase                        | `RouterTarget`, `AddressFamily`, `LocalSecretRef` |
+| Reference struct        | `{Target}Ref`                                 | `RouterRef`, `TargetRef`                       |
+| Selector struct         | `{Target}Selector`                            | `RouterSelector`                               |
+
+Condition type and reason constants are defined as untyped `string` constants (not a named type) in the same file as the resource they belong to.
+
+### kubebuilder Markers
+
+Every CRD root type requires these markers directly above the type declaration, in this order:
+
+```go
+// +kubebuilder:object:root=true
+// +kubebuilder:subresource:status
+// +kubebuilder:resource:scope=Namespaced,shortName=<abbrev>
+// +kubebuilder:printcolumn:name="...",type="...",JSONPath="..."
+// ... additional printcolumns
+type BGPFoo struct { ... }
+```
+
+Field-level validation markers appear directly above the field comment:
+
+```go
+// LocalASN is the BGP Autonomous System Number for this router.
+// +kubebuilder:validation:Required
+// +kubebuilder:validation:Minimum=1
+// +kubebuilder:validation:Maximum=4294967295
+LocalASN int64 `json:"localASN"`
+```
+
+CEL validation uses `XValidation`:
+
+```go
+// +kubebuilder:validation:XValidation:rule="isIP(self)",message="address must be a valid IPv4 or IPv6 address"
+```
+
+CEL functions `isIP()` and `isCIDR()` require Kubernetes 1.28+.
+
+For lists that are struct maps, use `+listType=map` and `+listMapKey=<key>`:
+
+```go
+// +listType=map
+// +listMapKey=type
+Conditions []metav1.Condition `json:"conditions,omitempty"`
+```
+
+For lists that enforce uniqueness, use `+listType=set`:
+
+```go
+// +listType=set
+Prefixes []string `json:"prefixes"`
+```
+
+### Status Conditions
+
+All status types that surface runtime state include:
+
+1. `ObservedGeneration int64` — set to the `.metadata.generation` the status was computed from.
+2. `Conditions []metav1.Condition` — with `+listType=map` and `+listMapKey=type`.
+
+```go
+type BGPFooStatus struct {
+    // +optional
+    ObservedGeneration int64 `json:"observedGeneration,omitempty"`
+
+    // +listType=map
+    // +listMapKey=type
+    // +optional
+    Conditions []metav1.Condition `json:"conditions,omitempty"`
+}
+```
+
+Condition type constants (`ConditionTypeReady`, `ConditionTypeAccepted`) are `string` constants, not a named type. Use `meta.SetStatusCondition` from `k8s.io/apimachinery/pkg/api/meta` to update conditions (it handles deduplication by type).
+
+### Field Types and Invariants
+
+**ASN fields must use `int64`**, never `int32`. The maximum valid ASN (4294967295) exceeds int32's maximum (2147483647). Using int32 produces an invalid OpenAPI v3 schema.
+
+**Router ID** is an IPv4 address expressed as a string with `// +kubebuilder:validation:Format=ipv4`. Even in IPv6-only underlays it is a logical identifier only.
+
+**Duration fields** use `*metav1.Duration` (pointer, so they can be omitted). CEL validation rules enforce hold-timer semantics.
+
+### JSON Serialization
+
+- Required fields: `json:"fieldName"` (no omitempty).
+- Optional fields: `json:"fieldName,omitempty"`.
+- Inline embedding: `json:",inline"` (no field name, e.g., `metav1.TypeMeta`, `metav1.ObjectMeta`, `RouterTarget`).
+- JSON field names are camelCase matching the Go field name (first letter lowercased).
+- Pointer fields (`*T`) are used exclusively for optional fields that can be absent vs. zero-valued.
+
+### Code Generation
+
+Two generated artifacts — never edit directly:
+
+| Artifact                   | Generator      | Regeneration command |
+|----------------------------|----------------|----------------------|
+| `zz_generated.deepcopy.go` | controller-gen | `task generate`      |
+| `config/crd/*.yaml`        | controller-gen | `task manifests`     |
+
+After changing any kubebuilder markers or adding/removing types: run both `task generate` and `task manifests`.
+
+The copyright/license header for generated files is in `hack/boilerplate.go.txt`.
+
+### Error Handling
+
+This is an API-only module — no request path, no controllers. Error handling is minimal:
+
+- Type methods that update status use the Kubernetes condition pattern (no returned `error`).
+- `fmt.Errorf` is used in status message strings, not for wrapping errors.
+- No panics in this codebase (init() only registers with the scheme builder).
+- No logging — API types have no logging infrastructure.
+
+### Go Testing
+
+- Framework: stdlib `testing` (no external test framework).
+- Table-driven via `t.Run` for parametric cases; dedicated function for single behaviors.
+- Test constructors are named `newTest{TypeName}(...)` (unexported, top of test file).
+- Pure helper functions (e.g., `findCondition`) do not call `t.Helper()` — they are not test helpers, they are utilities.
+- Tests call methods under test then use direct `t.Errorf` / `t.Fatalf` with `got %v, want %v` format.
+- Boundary value tests (especially ASN limits) are regression tests — they are named explicitly as such.
+- Run unit tests: `GOOS=linux go test ./api/bgp/v1alpha1/... -v`
+
+### Linting and Formatting
+
+- Linter: `golangci-lint` v2.1.6 — run via `task lint`.
+- Formatter: `go fmt` runs automatically as a dependency of `task build` and `task test:unit`.
+- `go vet` runs with `GOOS=linux` to catch cross-platform issues.
+- No `.golangci.yml` config file — default golangci-lint settings apply.
+
+---
+
+## YAML Conventions
+
+- All YAML files **must** use the `.yaml` extension. Files with `.yml` will fail the lint check (`task lint` enforces this).
+- YAML is formatted with `yamlfmt` v0.21.0. Run `task lint-fix` to auto-format.
+- CRD manifests in `config/crd/` are generated — do not edit manually.
+- Chainsaw test files follow the Chainsaw schema in `test/e2e/tests/`.
+
+---
+
+## Markdown Conventions
+
+- Markdown tables must have **aligned columns** — pad each cell with spaces so the `|` delimiters line up across all rows, including the separator row. Example:
+
+  ```markdown
+  | Construct  | Rule                           | Example         |
+  |------------|--------------------------------|-----------------|
+  | CRD root   | PascalCase, group prefix       | `BGPRouter`     |
+  | Spec type  | `{Resource}Spec`               | `BGPRouterSpec` |
+  ```
+
+  Not:
+
+  ```markdown
+  | Construct | Rule | Example |
+  |-----------|------|---------|
+  | CRD root | PascalCase, group prefix | `BGPRouter` |
+  ```
+
+- This applies to all `.md` files in the repository: docs, CONVENTIONS.md, ARCHITECTURE.md, CLAUDE.md, and inline docs.
+
+---
+
+## For Claude
+
+- **The single most important rule**: This is API-only Go. No controllers, no runtime, no logging, no error returns from type methods. Every new file goes in `api/<group>/v1alpha1/` and follows the `_types.go` naming pattern.
+- **ASN fields are always `int64`**. Never `int32`. Max ASN (4294967295) overflows int32. This is a hard invariant — the lint tests would catch it but the schema would silently break.
+- **Never edit `zz_generated.deepcopy.go` or `config/crd/*.yaml`**. Run `task generate` / `task manifests` instead.
+- **YAML files use `.yaml` extension only** — `.yml` fails CI.
+- New CRD resource → one `{resource}_types.go` file in the appropriate `api/<group>/v1alpha1/` package. Shared types used across resources in the same package go in `shared_types.go`.
+- Condition type constants are untyped `string` constants (not a named type), defined in the same file as the resource they describe.
+- Status types always include `ObservedGeneration int64` and `Conditions []metav1.Condition` with `+listType=map +listMapKey=type` markers.
+- Tests use stdlib `testing` only — no testify. Table-driven with `t.Run`, same-package (not `_test` suffix).
+- Commit messages follow Conventional Commits: `type(scope): message`. Scopes are `api`, `bgp`, `vpc`, `e2e`, `docs`.
+- **Three most common mistakes to avoid**:
+  1. Using `int32` for ASN fields — always use `int64`.
+  2. Adding omitempty to required fields or omitting it from optional fields.
+  3. Editing generated files directly instead of updating markers and re-running `task generate` + `task manifests`.
+- Comply with `go fmt` (auto-run by task), `go vet` (`GOOS=linux`), and `golangci-lint` defaults.

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -52,7 +52,7 @@ tasks:
 
   lint:
     desc: Run golangci-lint, yamlfmt, and yaml extension check
-    deps: [golangci-lint, yamlfmt]
+    deps: [tools:golangci-lint, tools:yamlfmt]
     cmds:
       - '{{.GOLANGCI_LINT}} run'
       - '{{.YAMLFMT}} -lint ./...'
@@ -69,7 +69,7 @@ tasks:
 
   lint-fix:
     desc: Run golangci-lint and yamlfmt with fixes
-    deps: [golangci-lint, yamlfmt]
+    deps: [tools:golangci-lint, tools:yamlfmt]
     cmds:
       - '{{.GOLANGCI_LINT}} run --fix'
       - '{{.YAMLFMT}} ./...'
@@ -90,13 +90,13 @@ tasks:
 
   generate:
     desc: Generate deepcopy methods
-    deps: [controller-gen]
+    deps: [tools:controller-gen]
     cmds:
       - '{{.CONTROLLER_GEN}} object:headerFile="hack/boilerplate.go.txt" paths="./..."'
 
   manifests:
     desc: Generate CRD manifests
-    deps: [controller-gen]
+    deps: [tools:controller-gen]
     cmds:
       - '{{.CONTROLLER_GEN}} crd paths="./api/..." output:crd:artifacts:config=config/crd'
 
@@ -131,7 +131,11 @@ tasks:
   ## Dependencies
   ##
 
-  golangci-lint:
+  tools:
+    desc: Install all development tools
+    deps: [tools:golangci-lint, tools:controller-gen, tools:chainsaw, tools:yamlfmt]
+
+  tools:golangci-lint:
     desc: Download golangci-lint locally if necessary
     run: once
     cmds:
@@ -141,7 +145,7 @@ tasks:
           PACKAGE: github.com/golangci/golangci-lint/v2/cmd/golangci-lint
           VERSION: '{{.GOLANGCI_LINT_VERSION}}'
 
-  controller-gen:
+  tools:controller-gen:
     desc: Download controller-gen locally if necessary
     run: once
     cmds:
@@ -151,7 +155,7 @@ tasks:
           PACKAGE: sigs.k8s.io/controller-tools/cmd/controller-gen
           VERSION: '{{.CONTROLLER_GEN_VERSION}}'
 
-  chainsaw:
+  tools:chainsaw:
     desc: Download chainsaw locally if necessary
     run: once
     cmds:
@@ -161,7 +165,7 @@ tasks:
           PACKAGE: github.com/kyverno/chainsaw
           VERSION: '{{.CHAINSAW_VERSION}}'
 
-  yamlfmt:
+  tools:yamlfmt:
     desc: Download yamlfmt locally if necessary
     run: once
     cmds:
@@ -170,10 +174,6 @@ tasks:
           TARGET: '{{.YAMLFMT}}'
           PACKAGE: github.com/google/yamlfmt/cmd/yamlfmt
           VERSION: '{{.YAMLFMT_VERSION}}'
-
-  tools:
-    desc: Install all development tools
-    deps: [golangci-lint, controller-gen, chainsaw, yamlfmt]
 
   install-tool:
     internal: true

--- a/api/bgp/v1alpha1/peer_types.go
+++ b/api/bgp/v1alpha1/peer_types.go
@@ -3,8 +3,8 @@ package v1alpha1
 import (
 	"fmt"
 
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // BGPPeerState represents the BGP Finite State Machine state of a session.

--- a/api/bgp/v1alpha1/router_types_test.go
+++ b/api/bgp/v1alpha1/router_types_test.go
@@ -143,10 +143,10 @@ func TestBGPRouterLargeLocalASN(t *testing.T) {
 		},
 		ObjectMeta: metav1.ObjectMeta{Name: "large-asn-router"},
 		Spec: BGPRouterSpec{
-			TargetRef:  TargetRef{Kind: "Node", Name: "node-1"},
-			LocalASN:   int64(maxASN),
-			RouterID:   "10.0.0.1",
-			Roles:      []RouterRole{RouterRoleTransit},
+			TargetRef: TargetRef{Kind: "Node", Name: "node-1"},
+			LocalASN:  int64(maxASN),
+			RouterID:  "10.0.0.1",
+			Roles:     []RouterRole{RouterRoleTransit},
 			AddressFamilies: []AddressFamily{
 				{AFI: AFIIPv4, SAFI: SAFIUnicast},
 			},
@@ -181,10 +181,10 @@ func TestBGPRouterLocalASNAboveSignedInt32Max(t *testing.T) {
 		},
 		ObjectMeta: metav1.ObjectMeta{Name: "above-int32-router"},
 		Spec: BGPRouterSpec{
-			TargetRef:  TargetRef{Kind: "Node", Name: "node-1"},
-			LocalASN:   aboveSignedMax,
-			RouterID:   "10.0.0.1",
-			Roles:      []RouterRole{RouterRoleTransit},
+			TargetRef: TargetRef{Kind: "Node", Name: "node-1"},
+			LocalASN:  aboveSignedMax,
+			RouterID:  "10.0.0.1",
+			Roles:     []RouterRole{RouterRoleTransit},
 			AddressFamilies: []AddressFamily{
 				{AFI: AFIIPv4, SAFI: SAFIUnicast},
 			},

--- a/docs/enhancements/ipv6-srv6-evpn-crd-analysis.md
+++ b/docs/enhancements/ipv6-srv6-evpn-crd-analysis.md
@@ -1,0 +1,622 @@
+# IPv6 SRv6 EVPN CRD Analysis & Recommendations
+
+**Status:** Draft
+**Date:** 2026-06-22
+**Scope:** All CRDs in `bgp.miloapis.com/v1alpha1` and `vpc.miloapis.com/v1alpha1`
+
+---
+
+## 1. Inventory
+
+| CRD | Scope | Purpose |
+|-----|-------|---------|
+| `BGPRouter` | Namespaced | BGP routing context: ASN, router ID, address families, roles |
+| `BGPPeer` | Namespaced | BGP session to a remote peer |
+| `BGPAdvertisement` | Namespaced | Prefix advertisement from a single router |
+| `BGPPolicy` | Namespaced | Import/export route filtering with ordered terms |
+| `BGPVRFInstance` | Namespaced | L2VPN EVPN VRF: RD, import/export RTs |
+| `VPC` | Namespaced | Virtual network with IPv4/IPv6 CIDR prefixes |
+| `VPCAttachment` | Namespaced | Binds a VPC to a named network interface |
+
+**Relationship:** `BGPRouter` is the anchor — all other BGP CRDs reference it via `routerRef` (single) or `routerSelector` (multiple). `BGPAdvertisement` deliberately only supports `routerRef`.
+
+---
+
+## 2. What's Already Good
+
+The API has a solid foundation:
+
+- **Clean ownership model** — `BGPRouter` as the anchor with `routerRef`/`routerSelector` targeting is well-designed
+- **CEL validation** — server-side validation for AFI/SAFI combos, IP/CIDR format, unique sequences, mutual exclusions
+- **Standard conditions** — `Ready` and `Accepted` condition types with reference implementations
+- **BGP FSM tracking** — `sessionState` enum covers all 6 states with Idle sub-reasons
+- **Address family abstraction** — AFI/SAFI struct prevents invalid combinations at admission time
+- **Policy model** — ordered terms with match/set semantics is BGP-accurate
+- **v1alpha1** — appropriate for an API that will evolve; no premature v1 commitment
+
+---
+
+## 3. Gaps for IPv6 SRv6 EVPN
+
+### 3.1 BGPVRFInstance — Missing EVPN Core Fields
+
+**Critical gap.** The current `BGPVRFInstance` only has RD and RTs. A production EVPN VRF needs:
+
+| Missing Field | Why It Matters |
+|---|---|
+| `vni` (uint32) | The VNI is the primary L2 segmentation identifier in EVPN. Without it, the VRF has no data-plane identity. RFC 7432 requires EVPN routes to carry a Route Distinguisher that includes the VNI. |
+| `autoRouteTarget` (bool) | Auto-RT discovery (RFC 8247) derives RTs from the VNI and RD automatically. Most modern EVPN deployments use this. Manual RT configuration per VRF doesn't scale. |
+| `importRouteTargets` / `exportRouteTargets` as optional | With auto-RT, these should not be required. |
+| `routeDistinguisher` derivation | RDs should be derivable from node IP + VNI (e.g., `RouterID:VNI`), making manual specification optional. |
+
+**Recommendation:** Make `importRouteTargets` and `exportRouteTargets` optional. Add `vni` as a required field when `l2vpn-evpn` is used. Add `autoRouteTarget` boolean. Derive default RD from `BGPRouter.routerID` + VNI.
+
+### 3.2 No SRv6 Support at All
+
+This is the largest gap. SRv6 requires several new resource types:
+
+#### 3.2.1 SRv6 SID Management
+
+SRv6 uses SIDs (Segment Identifiers — 128-bit IPv6 addresses) as network programming tokens. The API needs:
+
+```go
+type SRv6SIDBlock struct {
+    // Prefix is the SRv6 SID prefix (e.g., "2001:db8:sid::/48")
+    Prefix string `json:"prefix"`
+    // Length is the SID block length in bits (48-128, default 48)
+    Length int32 `json:"length,omitempty"`
+    // NodeSID is the local node's SID within this block
+    NodeSID *string `json:"nodeSid,omitempty"`
+}
+```
+
+**Where it lives:** Either as a new `SRv6SIDBlock` CRD or as a field on `BGPRouter.Spec`. Since SIDs are node-local, embedding in `BGPRouter` makes sense:
+
+```yaml
+spec:
+  srv6:
+    enabled: true
+    sidBlock:
+      prefix: "2001:db8:sid::"
+      length: 48
+    nodeSID: "2001:db8:sid::1"
+```
+
+#### 3.2.2 SRv6 Policy CRD
+
+SRv6 policies define segment lists (ordered lists of SIDs):
+
+```go
+type SRv6Policy struct {
+    // EndpointBehavior is the SRv6 endpoint behavior.
+    // Enum: End, End.X, End.DX2, End.DT6, End.UX6, End.B6, End.M
+    EndpointBehavior string `json:"endpointBehavior"`
+    // Preference is the policy preference (lower = higher priority).
+    Preference int32 `json:"preference"`
+    // Segments is the ordered list of SIDs forming the segment list.
+    Segments []SRv6Segment `json:"segments"`
+    // BindingType determines if this is a global policy or VRF-bound.
+    BindingType string `json:"bindingType"` // "global" | "vrf"
+    // VRFRef references a BGPVRFInstance when bindingType=vrf.
+    VRFRef *RouterRef `json:"vrfRef,omitempty"`
+}
+
+type SRv6Segment struct {
+    // Address is the 128-bit IPv6 SID.
+    Address string `json:"address"` // validated with isIPv6(self)
+    // Adapter is optional SRv6 adapter identifier (SID set index).
+    Adapter *string `json:"adapter,omitempty"`
+}
+```
+
+#### 3.2.3 SRv6 Transport Policy
+
+For SRv6-based underlay (IP-in-IPv6 tunneling between nodes):
+
+```go
+type SRv6TransportPolicy struct {
+    // Source is the local node SID prefix.
+    Source string `json:"source"`
+    // Destination is the remote node SID.
+    Destination string `json:"destination"`
+    // EndDX6 indicates decapsulation + L3 forwarding at the endpoint.
+    EndDX6 bool `json:"endDX6,omitempty"`
+    // EndDX2 indicates decapsulation + L2 forwarding at the endpoint.
+    EndDX2 bool `json:"endDX2,omitempty"`
+}
+```
+
+### 3.3 BGPPeer — Missing IPv6-First and EVPN Fields
+
+| Missing Field | Why It Matters |
+|---|---|
+| `holdTimer` / `keepaliveTimer` per-AFI | In EVPN, different AFI/SAFI may need different timers. Not strictly required but useful. |
+| `multiSession` (bool) | BFD over MP-BGP (RFC 8935) requires multi-session BGP. Each AFI/SAFI gets its own BFD session. |
+| `bfd` (BFD config struct) | BFD is essential for sub-500ms failure detection in EVPN. Without it, convergence relies on hold timers (typically 90s). |
+| `password` (plain text, optional) | MD5/TCP-AO auth via Secret is good, but some implementations need plain-text for simplicity in non-prod. |
+| `ebgpMultiHop` (bool) | Peers not on directly connected links. Required for spine-leaf or routed underlay. |
+| `routeMapIn` / `routeMapOut` | Policy attachment per-peer direction. Currently policies are router-scoped only. |
+| `nextHopSelf` (bool) | Common in EVPN iBGP peering. |
+| `removePrivateAS` (uint32) | Strip private ASNs on eBGP export. |
+| `defaultOriginRoute` (string) | Default route origination for EVPN. |
+| `gracefulRestart` (bool + timers) | BGP graceful restart (RFC 4724) is critical for EVPN to avoid MAC/IP flapping during control-plane restarts. |
+
+### 3.4 BGPPolicy — Limited Match/MatchSet Actions
+
+The current policy model is minimal. For a production EVPN/SRv6 deployment:
+
+| Missing Match Condition | Why It Matters |
+|---|---|
+| `prefixList` (name or inline) | Match routes against named/inline prefix-lists. Essential for EVPN route filtering. |
+| `asPathFilter` (name or inline) | Match/filter by AS path. Used for loop prevention and traffic engineering. |
+| `communityMatch` | Match routes by BGP community. Critical for EVPN route selection (e.g., prefer specific RTs). |
+| `routeType` (EVPN route type enum) | Match Type-1 (host route), Type-2 (MAC/IP), Type-3 (IP prefix), Type-4 (sticky), Type-5 (IP prefix). Needed for selective EVPN route import. |
+| `vni` (uint32) | Match by VNI in EVPN routes. |
+| `macAddress` (string) | Match MAC address in EVPN Type-2 routes. |
+| `ipPrefix` (cidr) | Match specific IP prefixes inline. |
+| `localPref` (match) | Match routes by LOCAL_PREF. |
+| `med` (match) | Match routes by MED. |
+
+| Missing Set Action | Why It Matters |
+|---|---|
+| `origin` (igp | egp | incomplete) | Set BGP origin attribute. |
+| `asPath` (prepend | set) | Prepend AS path or set it. |
+| `nextHop` (self | address) | Override next-hop. Critical for EVPN. |
+| `originatorID` | Set BGP originator ID (for route reflection). |
+| `clusterList` | Set BGP cluster list (for route reflection). |
+| `extCommunity` (add/remove) | Extended communities beyond standard communities. Needed for EVPN RT manipulation. |
+| `metric` (MED) | Set MED for traffic engineering. |
+| `color` (uint32) | Set SRv6 policy color for path selection. |
+| `srv6EndpointBehavior` | Set SRv6 endpoint behavior on a route. |
+
+### 3.5 BGPAdvertisement — Per-Prefix Attributes Missing
+
+Current model advertises a set of prefixes with uniform attributes. For SRv6/EVPN:
+
+| Missing Feature | Why It Matters |
+|---|---|
+| Per-prefix communities/localPref | Different prefixes may need different communities (e.g., loopback /128 vs. subnet routes). |
+| `originateFrom` (interface/route) | Originate routes from local interface addresses or kernel routes rather than static prefixes. |
+| `routeMap` (name) | Apply a route-map before advertisement for conditional origination. |
+| `redistribute` (static | connected | kernel) | Redistribute local routing table entries into BGP. |
+
+### 3.6 Route Target Format Too Restrictive
+
+Current regex only allows `ASN:NN` or `IP:NN`. RFC 6514 defines three RD/RT formats:
+
+1. **Type 0:** `ASN:NN` (2-byte ASN : 16-bit number) — max ASN 65535
+2. **Type 1:** `ASN:NN` (4-byte ASN : 16-bit number) — supports full 32-bit ASN range
+3. **Type 2:** `IP:NN` (4-octet IP : 16-bit number)
+
+The current regex `[0-9]{1,9}` for the first part allows up to 9 digits, which is fine for both 2-byte and 4-byte ASNs. However, the IP format regex `[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}` doesn't validate that each octet is 0-255.
+
+**Recommendation:** Add per-octet validation or switch to a format that uses `isIP()` for the IP portion. Also document that Type 0 (2-byte ASN) uses the `+kubebuilder:validation:Maximum=65535` constraint where applicable.
+
+### 3.7 KeepaliveTime Validation Missing
+
+`HoldTime` has CEL validation (`duration(self) == duration('0s') || duration(self) >= duration('3s')`), but `KeepaliveTime` has no validation. The BGP spec (RFC 4271) requires `keepalive <= holdTime / 3`.
+
+**Recommendation:** Add CEL validation. Since CEL can't express `self <= other / 3` easily with `metav1.Duration`, consider:
+- Adding a `+kubebuilder:validation:XValidation` that checks `duration(self) <= duration('30s')` with a default-based constraint
+- Or documenting the constraint strongly and enforcing it in the controller with an `Accepted=False` condition
+
+### 3.8 BGPRouter — RouterID IPv4-Only
+
+The `routerID` field uses `format: ipv4` (string format validation). In an IPv6-only underlay, this is a logical identifier only — the comment acknowledges this.
+
+**Recommendation:** Allow IPv6 RouterIDs. Use a CEL rule:
+
+```go
+// +kubebuilder:validation:XValidation:rule="isIP(self) || self.matches('^[0-9]{1,3}\\\\.[0-9]{1,3}\\\\.[0-9]{1,3}\\\\.[0-9]{1,3}$')",message="routerID must be a valid IPv4 or IPv6 address"
+```
+
+Or simply: `isIP(self)` — but note that `isIP()` in Kubernetes CEL accepts both IPv4 and IPv6, so this would work.
+
+### 3.9 No BFD Support
+
+BFD (Bidirectional Forwarding Detection) is critical for fast failure detection in EVPN deployments. Without BFD, convergence relies on BGP hold timers (default 90s), which is unacceptable for production.
+
+**Recommendation:** Add a `BGPPeerBFD` type:
+
+```go
+type BGPPeerBFD struct {
+    // Enabled indicates whether BFD is enabled for this peer.
+    Enabled bool `json:"enabled"`
+    // MinimumTX is the minimum transmission interval (microseconds).
+    MinimumTX *metav1.Duration `json:"minimumTx,omitempty"`
+    // MinimumRX is the minimum reception interval (microseconds).
+    MinimumRX *metav1.Duration `json:"minimumRx,omitempty"`
+    // MultiHop enables BFD for eBGP multi-hop sessions.
+    MultiHop bool `json:"multiHop,omitempty"`
+}
+```
+
+### 3.10 No BGP Graceful Restart
+
+Graceful restart (RFC 4724) is essential for EVPN to prevent MAC/IP flapping during controller/router restarts. Without it, a brief control-plane restart causes wholesale MAC route withdrawal and re-advertisement, triggering ARP storms.
+
+**Recommendation:** Add to `BGPRouter.Spec`:
+
+```go
+type BGPRouterGracefulRestart struct {
+    // Enabled indicates whether graceful restart is enabled.
+    Enabled bool `json:"enabled"`
+    // RestartTime is the maximum time to wait for recovery (seconds, 1-1200).
+    RestartTime *uint32 `json:"restartTime,omitempty"`
+    // StaleRouteTime is the maximum time to keep stale routes (seconds).
+    StaleRouteTime *uint32 `json:"staleRouteTime,omitempty"`
+    // HelperOnly restricts GR to helper role (don't restart own routes).
+    HelperOnly bool `json:"helperOnly,omitempty"`
+}
+```
+
+### 3.11 VPCAttachment — Weird Default
+
+The `VPCAttachmentInterface.Name` field has `+kubebuilder:validation:XValidation` with a default of `"galactic0"`. This looks like a placeholder/test value that should not be in production API:
+
+```go
+// +default:value="galactic0"
+Name string `json:"name"`
+```
+
+**Recommendation:** Remove the `galactic0` default. If a default is needed, use an empty string or a more meaningful default like `"eth0"`.
+
+### 3.12 No VRF-to-VRF Route Leak Control
+
+In multi-tenant EVPN, VRFs need controlled route leakage (VRF leaking). The current API has no mechanism to define which VRFs can leak routes to which other VRFs.
+
+**Recommendation:** Add a `VRFLeak` CRD or a `leaks` field on `BGPVRFInstance`:
+
+```go
+type VRFLeak struct {
+    // SourceVRF references the source VRF.
+    SourceVRF RouterRef `json:"sourceVrf"`
+    // DestinationVRF references the destination VRF.
+    DestinationVRF RouterRef `json:"destinationVrf"`
+    // RouteTargetMapping defines how RTs are translated.
+    RouteTargetMapping []RouteTargetMapping `json:"routeTargetMapping,omitempty"`
+}
+
+type RouteTargetMapping struct {
+    Source string `json:"source"`  // RT in source VRF
+    Target string `json:"target"`  // RT in destination VRF
+}
+```
+
+### 3.13 No EVPN-Specific Route Attributes in Policy
+
+EVPN has 5 route types, each with different semantics:
+
+| Type | Name | Use |
+|------|------|-----|
+| 1 | Inclusive Multicast Ethernet Tag | BUM traffic distribution |
+| 2 | MAC-IP Advertisement | Host reachability |
+| 3 | IP Prefix Advertisement | L3 route distribution |
+| 4 | Sticky MAC Address | MAC mobility |
+| 5 | IPv6 Prefix Advertisement | IPv6 L3 routes |
+
+The current `BGPPolicyMatch` has no way to match on EVPN route type, VNI, MAC address, or IP prefix.
+
+**Recommendation:** Extend `BGPPolicyMatch`:
+
+```go
+type BGPPolicyMatch struct {
+    // ... existing fields ...
+
+    // EVPNRouteType matches specific EVPN route types.
+    EVPNRouteType []EVPNRouteType `json:"evpnRouteType,omitempty"`
+
+    // VNI matches routes by VNI.
+    VNI *uint32 `json:"vni,omitempty"`
+
+    // MACAddress matches MAC-IP routes by MAC.
+    MACAddress *string `json:"macAddress,omitempty"`
+
+    // IPPrefix matches IP prefix routes.
+    IPPrefix *string `json:"ipPrefix,omitempty"`
+}
+
+type EVPNRouteType string
+
+const (
+    EVPNRouteTypeInclusiveMulticastTag EVPNRouteType = "InclusiveMulticastEthernetTag"
+    EVPNRouteTypeMACIPAdvertisement    EVPNRouteType = "MACIPAdvertisement"
+    EVPNRouteTypeIPPrefixAdvertisement EVPNRouteType = "IPPrefixAdvertisement"
+    EVPNRouteTypeStickyMACAddress      EVPNRouteType = "StickyMACAddress"
+    EVPNRouteTypeIPv6PrefixAdvertisement EVPNRouteType = "IPv6PrefixAdvertisement"
+)
+```
+
+### 3.14 No Peer Group Support
+
+BGP peer groups (RFC 4271) are critical for scalability. Without them, each peer is configured individually, which doesn't scale to hundreds of peers (common in spine-leaf or large fabric).
+
+**Recommendation:** Add a `BGPPeerGroup` CRD:
+
+```go
+type BGPPeerGroup struct {
+    // Peers is the list of peer specifications within this group.
+    Peers []BGPPeerGroupPeer `json:"peers"`
+    // RemoteASN is the common ASN for all peers in this group.
+    RemoteASN int64 `json:"remoteASN"`
+    // Description is a human-readable label.
+    Description string `json:"description,omitempty"`
+}
+
+type BGPPeerGroupPeer struct {
+    // Address is the peer's IP address.
+    Address string `json:"address"`
+    // Description is a per-peer override.
+    Description string `json:"description,omitempty"`
+}
+```
+
+### 3.15 Status Gaps
+
+Several status fields are missing that would be valuable for operations:
+
+| Missing Status Field | Resource | Why |
+|---|---|---|
+| `lastStateChange` | BGPPeer | When did the session last change state? |
+| `uptime` | BGPPeer | How long has the session been up? |
+| `prefixesReceived` | BGPPeer | Count of received prefixes per AFI/SAFI |
+| `prefixesAdvertised` | BGPPeer | Count of advertised prefixes per AFI/SAFI |
+| `messagesSent` / `messagesReceived` | BGPPeer | BGP message counters for troubleshooting |
+| `afiSafi` | BGPPeer | Per-AFI/SAFI negotiation status |
+| `vni` | BGPVRFInstance | Echo the VNI in status for quick lookup |
+| `evpnRouteCount` | BGPVRFInstance | Total EVPN routes per type |
+| `srv6PolicyCount` | SRv6Policy (new) | Number of active SRv6 policies |
+| `appliedSegments` | SRv6Policy (new) | Number of active segment list entries |
+
+### 3.16 No Label/Route Distinguisher Uniqueness Constraint
+
+There's no mechanism to prevent duplicate RDs across VRFs on the same router. Duplicate RDs cause route leaking between VRFs — a serious data-plane bug.
+
+**Recommendation:** Add a CEL validation on `BGPVRFInstance` that checks for uniqueness within the namespace (or cluster-scoped if feasible):
+
+```yaml
++x-kubernetes-validations:
+  - rule: "self.routeDistinguisher !=" (this is hard to enforce at CRD level;
+    better handled by controller with Accepted=False condition)
+```
+
+### 3.17 No Cluster-Scoped Resources
+
+Some resources (like SRv6 SID blocks, peer groups) are naturally cluster-scoped. All current resources are Namespaced, which limits their utility.
+
+**Recommendation:** Consider making `SRv6SIDBlock` and `BGPPeerGroup` cluster-scoped.
+
+### 3.18 VPC API — Missing EVPN Integration
+
+The VPC API (`vpc.miloapis.com/v1alpha1`) is decoupled from the BGP API. For an EVPN deployment, VPCs need to be advertised into BGP (via `BGPAdvertisement`) and associated with EVPN VRFs.
+
+**Recommendation:** Add a cross-reference field:
+
+```go
+type VPCSpec struct {
+    Networks []string `json:"networks"`
+    // BGPAdvertisementRef optionally references a BGPAdvertisement
+    // that originates these networks.
+    BGPAdvertisementRef *RouterRef `json:"bgpAdvertisementRef,omitempty"`
+    // VRFInstanceRef optionally binds this VPC to a BGPVRFInstance.
+    VRFInstanceRef *RouterRef `json:"vrfInstanceRef,omitempty"`
+}
+```
+
+---
+
+## 4. Recommended CRD Additions (New Types)
+
+| New CRD | Scope | Purpose |
+|---------|-------|---------|
+| `SRv6SIDBlock` | Cluster | SRv6 SID prefix allocation per node |
+| `SRv6Policy` | Namespaced | SRv6 segment-list policies |
+| `BGPPeerGroup` | Cluster | Scalable peer group definitions |
+| `VRFLeak` | Namespaced | Controlled route leakage between VRFs |
+
+---
+
+## 5. Prioritized Implementation Plan
+
+### P0 — Blockers for EVPN Production
+
+1. **Add `vni` to `BGPVRFInstance`** — required for any EVPN data-plane operation
+2. **Add `bfd` to `BGPPeer`** — required for sub-second failure detection
+3. **Add `gracefulRestart` to `BGPRouter`** — required to prevent flapping during restarts
+4. **Add `evpnRouteType` / `vni` / `macAddress` match to `BGPPolicyMatch`** — required for EVPN route filtering
+5. **Add `nextHopSelf` to `BGPPeer`** — required for iBGP EVPN peering
+
+### P1 — Important for SRv6
+
+6. **Add `srv6` block to `BGPRouter`** — SID block + node SID
+7. **Create `SRv6Policy` CRD** — segment-list policies
+8. **Add `color` set action to `BGPPolicy`** — SRv6 path selection
+9. **Add `extCommunity` (add/remove) to `PolicySetActions`** — EVPN RT manipulation
+10. **Add `routeType` set action** — BGP origin attribute
+
+### P2 — Operations & Scalability
+
+11. **Add `BGPPeerGroup` CRD** — peer scalability
+12. **Add status fields** — uptime, prefix counts, message counters
+13. **Add `bgpAdvertisementRef` / `vrfInstanceRef` to VPC** — cross-API integration
+14. **Add `autoRouteTarget` to `BGPVRFInstance`** — RT automation
+15. **Allow IPv6 RouterID** — IPv6-only underlay support
+16. **Add `ebgpMultiHop` to `BGPPeer`** — non-direct peering
+
+### P3 — Nice to Have
+
+17. **Add `VRFLeak` CRD** — multi-tenant route control
+18. **Add `redistribute` to `BGPAdvertisement`** — dynamic route origination
+19. **Add `multiSession` to `BGPPeer`** — BFD over MP-BGP
+20. **Add `asPathFilter` / `prefixList` match to `BGPPolicy`** — richer policy matching
+21. **Fix `keepaliveTime` validation** — CEL enforcement
+22. **Fix `RouteTarget` format validation** — per-octet IP validation
+
+---
+
+## 6. Example: Complete IPv6 SRv6 EVPN Configuration
+
+```yaml
+# --- SRv6 SID allocation ---
+apiVersion: bgp.miloapis.com/v1alpha1
+kind: SRv6SIDBlock
+metadata:
+  name: fabric-sid-block
+spec:
+  prefix: "2001:db8:sid::"
+  length: 48
+---
+# --- BGPRouter with SRv6 ---
+apiVersion: bgp.miloapis.com/v1alpha1
+kind: BGPRouter
+metadata:
+  name: leaf-1-underlay
+  namespace: fabric
+  labels:
+    bgp.miloapis.com/role: fabric
+spec:
+  targetRef:
+    kind: Node
+    name: leaf-1
+  roles:
+    - fabric
+  localASN: 65000
+  routerID: "10.255.0.1"
+  gracefulRestart:
+    enabled: true
+    restartTime: 120
+    staleRouteTime: 300
+  srv6:
+    enabled: true
+    sidBlock:
+      prefix: "2001:db8:sid::"
+      length: 48
+    nodeSID: "2001:db8:sid::1"
+  addressFamilies:
+    - afi: ipv6
+      safi: unicast
+    - afi: l2vpn
+      safi: evpn
+---
+# --- BGPPeer with BFD ---
+apiVersion: bgp.miloapis.com/v1alpha1
+kind: BGPPeer
+metadata:
+  name: leaf-1-to-spine-1
+  namespace: fabric
+spec:
+  routerRef:
+    name: leaf-1-underlay
+  peerASN: 65000
+  address: "2001:db8:fabric::2"
+  description: "spine-1"
+  ebgpMultiHop: false
+  bfd:
+    enabled: true
+    minimumTx: 300ms
+    minimumRx: 300ms
+    detectMultiplier: 3
+  gracefulRestart:
+    enabled: true
+  addressFamilies:
+    - afi: ipv6
+      safi: unicast
+    - afi: l2vpn
+      safi: evpn
+---
+# --- EVPN VRF with VNI ---
+apiVersion: bgp.miloapis.com/v1alpha1
+kind: BGPVRFInstance
+metadata:
+  name: tenant-alpha
+  namespace: fabric
+spec:
+  routerSelector:
+    matchLabels:
+      bgp.miloapis.com/role: tenant
+  routeDistinguisher: "10.255.0.1:100"
+  vni: 10100
+  autoRouteTarget: true
+  importRouteTargets:
+    - value: "65000:10100"
+  exportRouteTargets:
+    - value: "65000:10100"
+---
+# --- SRv6 Policy: End.X between leaf-1 and leaf-2 ---
+apiVersion: bgp.miloapis.com/v1alpha1
+kind: SRv6Policy
+metadata:
+  name: leaf-1-to-leaf-2-endx
+  namespace: fabric
+spec:
+  routerRef:
+    name: leaf-1-underlay
+  endpointBehavior: End.X
+  preference: 100
+  segments:
+    - address: "2001:db8:sid::1"  # leaf-1 SID (source)
+    - address: "2001:db8:sid::2"  # leaf-2 SID (destination)
+  bindingType: global
+---
+# --- EVPN-aware policy ---
+apiVersion: bgp.miloapis.com/v1alpha1
+kind: BGPPolicy
+metadata:
+  name: evpn-import-policy
+  namespace: fabric
+spec:
+  routerSelector:
+    matchLabels:
+      bgp.miloapis.com/role: tenant
+  direction: import
+  terms:
+    - sequence: 10
+      match:
+        addressFamilies:
+          - afi: l2vpn
+            safi: evpn
+        evpnRouteType:
+          - MACIPAdvertisement
+        vni: 10100
+      action: permit
+      set:
+        communities:
+          add: ["65000:10100"]
+    - sequence: 20
+      match:
+        addressFamilies:
+          - afi: l2vpn
+            safi: evpn
+        evpnRouteType:
+          - IPPrefixAdvertisement
+        vni: 10100
+      action: permit
+      set:
+        communities:
+          add: ["65000:10100"]
+    - sequence: 9999
+      match:
+        any: true
+      action: deny
+```
+
+---
+
+## 7. Summary of Changes by Category
+
+| Category | Current State | Recommended State |
+|----------|--------------|-------------------|
+| **EVPN VRF** | RD + RTs only | + VNI, auto-RT, route-type matching |
+| **SRv6** | None | + SID blocks, policies, segment lists |
+| **Peer BFD** | None | + per-peer BFD config |
+| **Graceful Restart** | None | + per-router GR config |
+| **Policy Match** | Any, AFI/SAFI only | + prefix-list, AS-path, community, route-type, VNI, MAC, IP prefix |
+| **Policy Set** | Communities, localPref | + extCommunity, origin, as-path, next-hop, color, metric |
+| **RouterID** | IPv4 only | IPv4 or IPv6 |
+| **Keepalive validation** | Comment only | CEL enforcement |
+| **Route Target format** | ASN:NN or IP:NN | Same, but fix IP octet validation |
+| **Status** | Basic FSM + conditions | + uptime, prefix counts, message counters, per-AFI/SAFI |
+| **Peer Groups** | None | + cluster-scoped BGPPeerGroup CRD |
+| **VPC-BGP integration** | None | + cross-reference fields |
+| **VRF Leaking** | None | + VRFLeak CRD or inline leaks |
+| **VPCAttachment.Name default** | "galactic0" | Remove or change to "eth0" |


### PR DESCRIPTION
## Summary

Add foundational project documentation and refactor Taskfile tool dependency resolution.

## Changes

### New documentation
- **AGENTS.md** — Project overview, commands, architecture, key invariants, code generation, and testing guide
- **ARCHITECTURE.md** — Full module/package reference, resource model, data flow, and constraints
- **CONVENTIONS.md** — Naming rules, kubebuilder marker patterns, status condition conventions, Go standards
- **CLAUDE.md** — Converted to symlink pointing to AGENTS.md
- **docs/enhancements/ipv6-srv6-evpn-crd-analysis.md** — CRD inventory and analysis for IPv6 SRv6 EVPN support

### Taskfile refactor
- Namespace all tool targets under `tools:` prefix (e.g. `tools:golangci-lint`) to avoid conflicts with task targets
- Update all `deps:` references to use the namespaced format (e.g. `tools:controller-gen`)

### Minor fixes
- Fix import order in `peer_types.go` (meta import before metav1)
- Align struct field formatting in `router_types_test.go`