### PR TITLE
docs: add project documentation and refactor Taskfile tool namespace

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,58 @@
+# ── Binaries & build artifacts ──────────────────────────────────────
 bin/
 *.exe
+*.exe~
+*.dll
+*.so
+*.dylib
 *.test
 *.out
 
-# E2E test artifacts
+# ── Go build cache / coverage ───────────────────────────────────────
+coverage.out
+coverage.txt
+*.coverprofile
+go.build/
+
+# ── Generated files (regenerate with `task generate` / `task manifests`)
+api/**/zz_generated.deepcopy.go
+config/crd/
+
+# ── IDE ─────────────────────────────────────────────────────────────
+.idea/
+.vscode/
+*.swp
+*.swo
+*~
+*.bak
+*.sublime-project
+*.sublime-workspace
+
+# ── macOS ───────────────────────────────────────────────────────────
+.DS_Store
+.AppleDouble
+.LSOverride
+
+# ── Windows ─────────────────────────────────────────────────────────
+Thumbs.db
+ehthumbs.db
+Desktop.ini
+$RECYCLE.BIN/
+
+# ── Linux / file-manager trash ──────────────────────────────────────
+.Trash-*/
+
+# ── E2E test artifacts ─────────────────────────────────────────────
 test/e2e/.kubeconfig
 test/e2e/.kubeconfig.lock
+test/e2e/kind-cluster*
+
+# ── Task / build cache ─────────────────────────────────────────────
+.task/
+
+# ── Environment / secrets ──────────────────────────────────────────
+.env
+.env.*
+!.env.example
+.local
+

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,89 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## What this project is
+
+Cosmos defines Kubernetes CRDs and API types for BGP routing and virtual networking. It is **API-only** — no controllers, no binaries, no runtime. Implementations consume these APIs; this repo just defines the contract.
+
+Module: `go.miloapis.com/cosmos`
+
+## Commands
+
+This project uses [Task](https://taskfile.dev/) (`task`), not `make`.
+
+```bash
+task tools        # Install all dev tools into ./bin/ (run first)
+task build        # go fmt + go vet + go build ./...
+task test:unit    # Run unit tests with coverage (excludes /e2e)
+task test:e2e     # Create kind cluster, deploy CRDs, run Chainsaw tests, teardown
+task lint         # golangci-lint + yamlfmt check
+task lint-fix     # Same with auto-fix applied
+task generate     # Regenerate zz_generated.deepcopy.go files
+task manifests    # Regenerate CRD YAML in config/crd/ from Go types
+task ci           # Full local pipeline: build → lint → test:unit → test:e2e
+task clean        # Remove ./bin/ and cover.out
+```
+
+Run a single unit test package:
+```bash
+GOOS=linux go test ./api/bgp/v1alpha1/... -run TestName -v
+```
+
+All dev tools (golangci-lint, controller-gen, chainsaw, yamlfmt) are installed locally to `./bin/` — they are never installed system-wide.
+
+## Architecture
+
+### API groups
+
+| Group              | Version    | Resources                                                       |
+|--------------------|------------|-----------------------------------------------------------------|
+| `bgp.miloapis.com` | `v1alpha1` | BGPRouter, BGPPeer, BGPAdvertisement, BGPPolicy, BGPVRFInstance |
+| `vpc.miloapis.com` | `v1alpha1` | VPC, VPCAttachment                                              |
+
+Source lives in `api/bgp/v1alpha1/` and `api/vpc/v1alpha1/`. Each resource has its own `*_types.go` file; shared types (RouterTarget, AddressFamily, etc.) live in `shared_types.go`.
+
+### BGP resource ownership model
+
+`BGPRouter` is the ownership boundary — one per routing plane per node. All other BGP resources bind to routers:
+
+- `routerRef` — binds to a single BGPRouter by name (used by BGPPeer, BGPPolicy, BGPAdvertisement)
+- `routerSelector` — binds to multiple BGPRouters by label (used by BGPPeer, BGPPolicy)
+- `BGPAdvertisement` only supports `routerRef` (single-router scope)
+
+The `RouterTarget` struct (in `shared_types.go`) is embedded by resources that support either binding. It carries a CEL validation rule enforcing exactly-one-of.
+
+### Key invariants
+
+- **ASN fields are `int64`** — `int32` produces an invalid OpenAPI v3 schema (max ASN > int32 max). Never use `int32` for ASN.
+- **Kubernetes 1.28+ required** — CEL functions `isIP()` and `isCIDR()` are used for field validation.
+- **Status conditions** follow `metav1.Condition` conventions. Condition type constants (e.g., `ConditionTypeReady`, `ConditionTypeAccepted`) are defined alongside the resource type they belong to.
+- **YAML files must use `.yaml` extension**, never `.yml` — the lint task enforces this.
+
+### Code generation
+
+After changing kubebuilder markers (`// +kubebuilder:...`) or adding new types:
+
+1. `task generate` — regenerates `zz_generated.deepcopy.go`
+2. `task manifests` — regenerates CRDs in `config/crd/`
+
+Both are generated; never edit `zz_generated.deepcopy.go` or CRD YAML directly.
+
+### Testing
+
+Unit tests (`api/**/*_types_test.go`) test validation, defaulting, and marshaling logic. E2E tests use [Chainsaw](https://kyverno.github.io/chainsaw/) against a dual-stack kind cluster (config at `test/e2e/kind-config.yaml`). The e2e suite is driven by `scripts/e2e.sh` and requires Docker.
+
+## Architecture Reference
+
+See [ARCHITECTURE.md](docs/agents/ARCHITECTURE.md) for a full architecture reference including module layout, package roles, resource model, data flow, and known constraints.
+
+## Conventions Reference
+
+See [CONVENTIONS.md](docs/agents/CONVENTIONS.md) for coding standards, naming rules, kubebuilder marker patterns, status condition conventions, and Go-specific conventions.
+
+## Docs
+
+- `docs/api/bgp.md` — full BGP CRD field reference
+- `docs/api/vpc.md` — full VPC CRD field reference
+- `docs/getting-started.md` — install and first resources
+- `docs/enhancements/` — design proposals

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -52,7 +52,7 @@ tasks:
 
   lint:
     desc: Run golangci-lint, yamlfmt, and yaml extension check
-    deps: [golangci-lint, yamlfmt]
+    deps: [tools:golangci-lint, tools:yamlfmt]
     cmds:
       - '{{.GOLANGCI_LINT}} run'
       - '{{.YAMLFMT}} -lint ./...'
@@ -69,7 +69,7 @@ tasks:
 
   lint-fix:
     desc: Run golangci-lint and yamlfmt with fixes
-    deps: [golangci-lint, yamlfmt]
+    deps: [tools:golangci-lint, tools:yamlfmt]
     cmds:
       - '{{.GOLANGCI_LINT}} run --fix'
       - '{{.YAMLFMT}} ./...'
@@ -90,13 +90,13 @@ tasks:
 
   generate:
     desc: Generate deepcopy methods
-    deps: [controller-gen]
+    deps: [tools:controller-gen]
     cmds:
       - '{{.CONTROLLER_GEN}} object:headerFile="hack/boilerplate.go.txt" paths="./..."'
 
   manifests:
     desc: Generate CRD manifests
-    deps: [controller-gen]
+    deps: [tools:controller-gen]
     cmds:
       - '{{.CONTROLLER_GEN}} crd paths="./api/..." output:crd:artifacts:config=config/crd'
 
@@ -131,7 +131,11 @@ tasks:
   ## Dependencies
   ##
 
-  golangci-lint:
+  tools:
+    desc: Install all development tools
+    deps: [tools:golangci-lint, tools:controller-gen, tools:chainsaw, tools:yamlfmt]
+
+  tools:golangci-lint:
     desc: Download golangci-lint locally if necessary
     run: once
     cmds:
@@ -141,7 +145,7 @@ tasks:
           PACKAGE: github.com/golangci/golangci-lint/v2/cmd/golangci-lint
           VERSION: '{{.GOLANGCI_LINT_VERSION}}'
 
-  controller-gen:
+  tools:controller-gen:
     desc: Download controller-gen locally if necessary
     run: once
     cmds:
@@ -151,7 +155,7 @@ tasks:
           PACKAGE: sigs.k8s.io/controller-tools/cmd/controller-gen
           VERSION: '{{.CONTROLLER_GEN_VERSION}}'
 
-  chainsaw:
+  tools:chainsaw:
     desc: Download chainsaw locally if necessary
     run: once
     cmds:
@@ -161,7 +165,7 @@ tasks:
           PACKAGE: github.com/kyverno/chainsaw
           VERSION: '{{.CHAINSAW_VERSION}}'
 
-  yamlfmt:
+  tools:yamlfmt:
     desc: Download yamlfmt locally if necessary
     run: once
     cmds:
@@ -170,10 +174,6 @@ tasks:
           TARGET: '{{.YAMLFMT}}'
           PACKAGE: github.com/google/yamlfmt/cmd/yamlfmt
           VERSION: '{{.YAMLFMT_VERSION}}'
-
-  tools:
-    desc: Install all development tools
-    deps: [golangci-lint, controller-gen, chainsaw, yamlfmt]
 
   install-tool:
     internal: true

--- a/docs/agents/ARCHITECTURE.md
+++ b/docs/agents/ARCHITECTURE.md
@@ -1,0 +1,446 @@
+# Architecture
+
+> Cosmos is a Go module that defines Kubernetes CRDs and API types for BGP routing and virtual networking. It is consumed as a library by external controller implementations; this repository contains no runtime code.
+
+_Last updated: 2026-06-23_
+
+---
+
+## Table of Contents
+
+1. [Overview](#overview)
+2. [Repository Layout](#repository-layout)
+3. [Module / Package Reference](#module--package-reference)
+   - [api/bgp/v1alpha1](#apibgpv1alpha1)
+   - [api/vpc/v1alpha1](#apivpcv1alpha1)
+4. [API Resource Model](#api-resource-model)
+   - [BGP Group](#bgp-group-bgpmiloapis)
+   - [VPC Group](#vpc-group-vpcmiloapis)
+5. [Entry Points](#entry-points)
+6. [Data Flow](#data-flow)
+7. [External Dependencies](#external-dependencies)
+8. [Testing](#testing)
+9. [CI/CD](#cicd)
+10. [Known Constraints & Tech Debt](#known-constraints--tech-debt)
+11. [For Claude](#for-claude)
+
+---
+
+## Overview
+
+Cosmos defines the Kubernetes Custom Resource Definitions (CRDs) and Go API types for two networking domains:
+
+- **BGP routing** (`bgp.miloapis.com`) — abstractions for BGP routers, peers, advertisements, policies, and L2VPN/EVPN VRF instances
+- **Virtual networking** (`vpc.miloapis.com`) — abstractions for virtual private clouds and interface attachments
+
+The module is a **library**, not a binary. External controllers import `go.miloapis.com/cosmos` to register these types with their scheme and reconcile the resources. Cosmos itself ships only the type definitions, validation rules, CRD YAML, and their tests. There are no controllers, no HTTP servers, no goroutines, and no persistent state within this module.
+
+The design follows standard Kubernetes API conventions: resources have a `Spec` (desired state), a `Status` (observed state), and standard `metav1.Condition` conditions. CEL validation rules embedded in kubebuilder markers enforce invariants at the API server level (requiring Kubernetes 1.28+).
+
+---
+
+## Repository Layout
+
+```
+cosmos/
+├── api/
+│   ├── bgp/v1alpha1/          # bgp.miloapis.com/v1alpha1 — 5 CRD types + generated deepcopy
+│   └── vpc/v1alpha1/          # vpc.miloapis.com/v1alpha1 — 2 CRD types + generated deepcopy
+├── config/
+│   ├── crd/                   # Generated CRD YAML (controller-gen output — never edit directly)
+│   └── samples/               # Example resource manifests
+├── docs/
+│   ├── api/                   # Human-readable field reference (bgp.md, vpc.md)
+│   ├── design/                # Design notes
+│   ├── diagrams/              # PlantUML source and rendered diagrams
+│   └── enhancements/          # Design proposals (KEP-style)
+├── hack/
+│   └── boilerplate.go.txt     # Copyright header injected into generated files
+├── scripts/
+│   └── e2e.sh                 # E2E orchestration script (setup → test → teardown)
+├── test/e2e/
+│   ├── chainsaw-config.yaml   # Chainsaw timeouts and cluster name
+│   ├── kind-config.yaml       # kind cluster: 1 control-plane + 3 workers, dual-stack
+│   ├── Taskfile.yaml          # E2E task targets (cluster, Cilium, CRDs, Chainsaw)
+│   ├── fixtures/              # Shared test fixtures (BGPRouter manifests per node)
+│   └── tests/                 # One directory per Chainsaw test scenario
+├── bin/                       # Local dev tool binaries (gitignored)
+├── go.mod                     # Module: go.miloapis.com/cosmos, Go 1.26
+├── go.sum
+├── Taskfile.yaml              # Primary task runner (build, lint, test, generate, manifests)
+├── AGENTS.md                  # CLAUDE.md symlink target — project guidance for Claude Code
+└── CLAUDE.md -> AGENTS.md     # Symlink: CLAUDE.md → AGENTS.md
+```
+
+---
+
+## Module / Package Reference
+
+### api/bgp/v1alpha1
+
+**Purpose:** Defines all Go types, validation rules, and scheme registration for the `bgp.miloapis.com/v1alpha1` API group. Contains five CRD resources and their shared supporting types.
+
+**Key files:**
+
+| File                        | Contents                                                                                                                                                           |
+|-----------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `groupversion_info.go`      | `GroupVersion`, `SchemeBuilder`, `AddToScheme` — scheme registration entry point                                                                                  |
+| `router_types.go`           | `BGPRouter`, `BGPRouterSpec`, `BGPRouterStatus`                                                                                                                   |
+| `peer_types.go`             | `BGPPeer`, `BGPPeerSpec`, `BGPPeerStatus`, condition constants, `updatePeerConditions`, `SetAcceptedCondition`                                                     |
+| `advertisement_types.go`    | `BGPAdvertisement`, `BGPAdvertisementSpec`, `BGPAdvertisementStatus`                                                                                              |
+| `policy_types.go`           | `BGPPolicy`, `BGPPolicySpec`, `BGPPolicyTerm`, `BGPPolicyMatch`, `PolicySetActions`, `CommunitySet`                                                               |
+| `vrf_types.go`              | `BGPVRFInstance`, `BGPVRFInstanceSpec`, `BGPVRFInstanceStatus`, `RouteTarget`                                                                                     |
+| `shared_types.go`           | `RouterTarget`, `RouterRef`, `RouterSelector`, `TargetRef`, `AddressFamily`, `AFI`, `SAFI`, `RouterRole`, `LocalSecretRef`, `RouterStatus`, `ResolvedRouterConfig` |
+| `zz_generated.deepcopy.go`  | Generated `DeepCopy*` methods — do not edit                                                                                                                       |
+
+**External dependencies:**
+- `k8s.io/apimachinery/pkg/apis/meta/v1` — `metav1.TypeMeta`, `metav1.ObjectMeta`, `metav1.Condition`, `metav1.Duration`, `metav1.Time`
+- `k8s.io/apimachinery/pkg/api/meta` — `meta.SetStatusCondition` (used in peer condition helpers)
+- `sigs.k8s.io/controller-runtime/pkg/scheme` — `scheme.Builder` for type registration
+
+**Owns persistent state:** No.
+
+---
+
+### api/vpc/v1alpha1
+
+**Purpose:** Defines all Go types and scheme registration for the `vpc.miloapis.com/v1alpha1` API group. Contains two CRD resources.
+
+**Key files:**
+
+| File                        | Contents                                                                                                                   |
+|-----------------------------|----------------------------------------------------------------------------------------------------------------------------|
+| `groupversion_info.go`      | `GroupVersion`, `SchemeBuilder`, `AddToScheme`                                                                             |
+| `vpc_types.go`              | `VPC`, `VPCSpec`, `VPCStatus`                                                                                              |
+| `vpcattachment_types.go`    | `VPCAttachment`, `VPCAttachmentSpec`, `VPCAttachmentStatus`, `VPCRef`, `VPCAttachmentInterface`, `VPCAttachmentAnnotation` |
+| `zz_generated.deepcopy.go`  | Generated `DeepCopy*` methods — do not edit                                                                                |
+
+**External dependencies:**
+- `k8s.io/apimachinery/pkg/apis/meta/v1` — `metav1.TypeMeta`, `metav1.ObjectMeta`
+- `sigs.k8s.io/controller-runtime/pkg/scheme` — `scheme.Builder`
+
+**Owns persistent state:** No.
+
+---
+
+## API Resource Model
+
+### BGP Group (`bgp.miloapis.com`)
+
+`BGPRouter` is the ownership root. Every other BGP resource binds to one or more routers.
+
+```mermaid
+graph TD
+    Node["Kubernetes Node"]
+    Router["BGPRouter\n(1 per routing plane per node)"]
+    Peer["BGPPeer\n(remote session)"]
+    Adv["BGPAdvertisement\n(prefixes to originate)"]
+    Policy["BGPPolicy\n(import/export rules)"]
+    VRF["BGPVRFInstance\n(L2VPN EVPN VRF)"]
+
+    Node -->|targetRef| Router
+    Router -->|routerRef| Peer
+    Router -->|routerRef| Adv
+    Router -->|routerRef or routerSelector| Policy
+    Router -->|routerRef or routerSelector| VRF
+```
+
+**BGPRouter** — `bgprouters.bgp.miloapis.com`, shortName `bgpr`
+
+One per routing plane per node. Declares the local ASN, router ID, address families, and node binding. Acts as the namespace-scoped ownership boundary for all other BGP resources.
+
+Key spec fields:
+- `targetRef.kind/name` — identifies the Kubernetes Node this router runs on
+- `roles` — one or more of `fabric`, `tenant`, `transit` (at least one required)
+- `localASN int64` — 2-byte or 4-byte BGP ASN (1–4294967295)
+- `routerID string` — IPv4 dotted-decimal notation (logical identifier in IPv6-only underlays)
+- `addressFamilies []AddressFamily` — AFI/SAFI pairs this router activates
+
+Status: `phase` (Pending/Ready/Failed), `observedGeneration`, `peers` (total/established counts), `conditions`.
+
+---
+
+**BGPPeer** — `bgppeers.bgp.miloapis.com`, shortName `bgppr`
+
+A BGP session to a remote peer. Binds to one or more BGPRouters via `routerRef` (single) or `routerSelector` (multi). Exactly one binding must be set — enforced by CEL.
+
+Key spec fields:
+- `RouterTarget` (inline) — `routerRef` or `routerSelector`
+- `peerASN int64` — remote AS number
+- `address string` — remote IPv4 or IPv6 address (CEL: `isIP(self)`)
+- `addressFamilies []AddressFamily` — AFI/SAFI pairs negotiated on this session
+- `holdTime *metav1.Duration` — 0 (disabled) or ≥3s; defaults to 90s
+- `keepaliveTime *metav1.Duration` — must be ≤ holdTime/3; defaults to 30s
+- `authSecretRef *LocalSecretRef` — optional MD5 TCP auth (key: `"password"`)
+
+Status: `sessionState` (BGP FSM state), `lastEstablishedTime`, `observedGeneration`, `conditions`.
+
+Condition constants defined in `peer_types.go`: `ConditionTypeReady`, `ConditionTypeAccepted`. Idle reason constants: `IdleReasonBackOff`, `IdleReasonConnectionRefused`, `IdleReasonHoldTimerExpired`, `IdleReasonIdle`.
+
+Status helper methods (reference implementation for controller authors):
+- `updatePeerConditions(state, gen, idleReason)` — sets Ready condition from FSM state
+- `SetAcceptedCondition(accepted, gen, reason, message)` — sets Accepted condition
+
+---
+
+**BGPAdvertisement** — `bgpadvertisements.bgp.miloapis.com`, shortName `bgpadv`
+
+Prefixes to originate from a single BGPRouter. Intentionally supports only `routerRef` (not `routerSelector`) to avoid ambiguous prefix attribution across multiple routers.
+
+Key spec fields:
+- `routerRef RouterRef` — direct binding to one BGPRouter (required)
+- `addressFamily AddressFamily` — AFI/SAFI for this advertisement
+- `prefixes []string` — 1–256 CIDR prefixes; each validated via CEL `isCIDR()`; `+listType=set`
+- `communities []string` — 0–64 BGP communities in `ASN:NN` or `IP:NN` format
+- `localPreference *uint32` — BGP LOCAL_PREF (iBGP only)
+
+---
+
+**BGPPolicy** — `bgppolicies.bgp.miloapis.com`, shortName `bgpp`
+
+Composable, ordered routing policy applied to a BGPRouter in one direction (import or export). Binds via `routerRef` or `routerSelector`.
+
+Key spec fields:
+- `RouterTarget` (inline)
+- `direction BGPPolicyDirection` — `import` or `export`
+- `terms []BGPPolicyTerm` — 1–32 terms, each with a unique `sequence int32`, a `match`, and an `action` (`permit`/`deny`)
+
+Term match fields: `any bool`, `addressFamilies []AddressFamily`.
+Term set actions (permit only): `communities` (add/remove lists), `localPreference`.
+
+CEL invariants: sequence numbers must be unique; `set` must not be present on `deny` terms.
+
+---
+
+**BGPVRFInstance** — `bgpvrfinstances.bgp.miloapis.com`, shortName `bgpvrf`
+
+Configures an L2VPN EVPN VRF on matched BGPRouters. The targeted BGPRouter must have `l2vpn/evpn` in its `addressFamilies`.
+
+Key spec fields:
+- `RouterTarget` (inline)
+- `routeDistinguisher string` — uniquely identifies the VRF; `ASN:NN` or `IP:NN` format
+- `importRouteTargets []RouteTarget` — 1–32 RT extended communities for route import
+- `exportRouteTargets []RouteTarget` — 1–32 RT extended communities for route export
+
+Status: top-level `conditions`, plus per-router `routers []RouterStatus` (`+listType=map +listMapKey=routerName`). `RouterStatus` holds per-router conditions and a `ResolvedRouterConfig` snapshot.
+
+---
+
+### VPC Group (`vpc.miloapis.com`)
+
+**VPC** — `vpcs.vpc.miloapis.com`
+
+A virtual private cloud defined by CIDR blocks.
+
+Key spec fields:
+- `networks []string` — 1–64 IPv4 or IPv6 CIDRs; validated via CEL `isCIDR()`
+
+Status: `ready bool`, `identifier string`.
+
+---
+
+**VPCAttachment** — `vpcattachments.vpc.miloapis.com`
+
+Attaches a network interface to a VPC.
+
+Key spec fields:
+- `vpc VPCRef` — reference to a VPC by name in the same namespace
+- `interface VPCAttachmentInterface` — interface name and 1–16 IPv4/IPv6 addresses (each validated via CEL `isCIDR()`)
+
+Status: `ready bool`, `identifier string`.
+
+Annotation: `k8s.v1alpha1.vpc.miloapis.com/vpc-attachment` (constant `VPCAttachmentAnnotation`).
+
+---
+
+## Entry Points
+
+This module has no binaries. It is imported by external controllers as a Go library.
+
+To register BGP types with a controller-runtime scheme:
+```go
+import bgpv1alpha1 "go.miloapis.com/cosmos/api/bgp/v1alpha1"
+
+scheme.AddToScheme(bgpv1alpha1.AddToScheme)
+```
+
+To register VPC types:
+```go
+import vpcv1alpha1 "go.miloapis.com/cosmos/api/vpc/v1alpha1"
+
+scheme.AddToScheme(vpcv1alpha1.AddToScheme)
+```
+
+Both `AddToScheme` values are produced by `sigs.k8s.io/controller-runtime/pkg/scheme.Builder` and registered via `init()` in each `*_types.go` file.
+
+---
+
+## Data Flow
+
+There is no runtime data flow within this module. The flow belongs to external controllers that import these types:
+
+```
+User applies YAML manifest
+        │
+        ▼
+Kubernetes API Server
+  validates against CRD schema (CEL rules embedded in config/crd/*.yaml)
+        │
+        ▼
+etcd (resource stored)
+        │
+        ▼
+External controller (watches the API group via controller-runtime)
+  imports go.miloapis.com/cosmos API types to decode resources
+        │
+        ▼
+Controller reconciles: configures underlying BGP daemon (FRR, GoBGP, etc.)
+        │
+        ▼
+Controller writes back .status (sessionState, conditions, observedGeneration)
+```
+
+The CRD YAML in `config/crd/` is the artifact deployed to a cluster. CEL rules in those manifests enforce field-level invariants at admission time (before a resource is stored), independent of any controller.
+
+---
+
+## External Dependencies
+
+| Dependency                        | Version  | Purpose                                                                   |
+|-----------------------------------|----------|---------------------------------------------------------------------------|
+| `k8s.io/api`                      | v0.33.0  | Core Kubernetes API types                                                 |
+| `k8s.io/apimachinery`             | v0.33.0  | `metav1` types, `meta.SetStatusCondition`, scheme/GVK machinery           |
+| `sigs.k8s.io/controller-runtime`  | v0.21.0  | `scheme.Builder` for type registration (only the scheme package is used)  |
+
+All other entries in `go.sum` are transitive dependencies of the above three.
+
+**Dev tooling (local to `./bin/`, not in `go.mod`):**
+
+| Tool              | Version  | Purpose                                                                                |
+|-------------------|----------|----------------------------------------------------------------------------------------|
+| `controller-gen`  | v0.18.0  | Generates `zz_generated.deepcopy.go` and `config/crd/*.yaml` from kubebuilder markers |
+| `golangci-lint`   | v2.1.6   | Go linting                                                                             |
+| `yamlfmt`         | v0.21.0  | YAML formatting; enforces consistent style                                             |
+| `chainsaw`        | v0.2.12  | Kubernetes-native e2e test runner                                                      |
+
+---
+
+## Testing
+
+### Unit tests
+
+- Location: `api/bgp/v1alpha1/*_types_test.go`
+- Framework: stdlib `testing` (no external test framework)
+- Coverage: DeepCopy correctness, JSON round-trip fidelity, JSON field name verification, boundary values (max 4-byte ASN), status condition logic (`updatePeerConditions`, `SetAcceptedCondition`)
+- Run: `GOOS=linux go test ./api/bgp/v1alpha1/... -v`  or `task test:unit`
+
+There are no unit tests for the VPC package (VPC types have no methods beyond generated DeepCopy).
+
+### E2E tests
+
+- Location: `test/e2e/tests/` (one directory per scenario)
+- Framework: [Chainsaw](https://kyverno.github.io/chainsaw/) v0.2.12
+- Cluster: kind cluster `bgp-e2e` with 1 control-plane + 3 worker nodes, dual-stack (`ipFamily: dual`), Cilium CNI
+- Kubernetes version: `kindest/node:v1.34.0`
+
+E2E test scenarios:
+
+| Scenario                   | What it tests                                               |
+|----------------------------|-------------------------------------------------------------|
+| `system-readiness`         | Cluster and CRD readiness after deploy                      |
+| `bgp-peering`              | BGPPeer CRUD, full-mesh IPv6 peer creation across 3 workers |
+| `bgp-peer-timers`          | HoldTime/KeepaliveTime field acceptance                     |
+| `bgp-advertisement`        | BGPAdvertisement resource acceptance and schema validation   |
+| `bgp-policy`               | BGPPolicy resource acceptance                               |
+| `bgp-status-conditions`    | Status condition writes                                     |
+| `bgp-vrf-crd-schema`       | BGPVRFInstance schema validation (RD, RT format)            |
+| `vpc-crd-schema`           | VPC and VPCAttachment schema validation                     |
+
+Chainsaw timeouts: apply=2m, assert=5m, delete=2m, exec=3m.
+
+E2E setup steps (via `scripts/e2e.sh` → `test/e2e/Taskfile.yaml`):
+1. Create kind cluster with dual-stack networking
+2. Install Cilium v1.17.3 (CNI, non-exclusive mode)
+3. Apply all CRDs via `kubectl apply -k config/crd/`
+4. Apply BGPRouter fixtures for each worker node
+5. Run Chainsaw tests (sequential: `--parallel 1`)
+6. Teardown cluster on exit (trap)
+
+Run: `task test:e2e` (requires Docker, kind, kubectl, chainsaw, helm in PATH).
+
+---
+
+## CI/CD
+
+### Pipeline (`.github/workflows/ci.yaml`)
+
+```
+push/PR → main
+      │
+      ├── Build (go fmt + go vet + go build)
+      │         │
+      │    ┌────┴────┐
+      │    │         │
+      │  Test       Lint
+      │  (unit)     (golangci-lint + yamlfmt + .yml check)
+      │    │         │
+      │    └────┬────┘
+      │         │
+      │        E2E
+      │   (kind cluster, 30m timeout)
+```
+
+All jobs use Go 1.26 and cache the Go module download.
+
+### Docker workflow (`.github/workflows/docker.yaml`)
+
+Triggers: after CI succeeds on `main`, or on `v*` tag pushes.
+Registry: `ghcr.io` (GitHub Container Registry).
+Platforms: `linux/amd64`, `linux/arm64`.
+Source: `build/Dockerfile` — **this file does not currently exist in the repository**. The workflow is present but will fail until a Dockerfile is added to `build/`.
+
+### Dependency updates (Renovate)
+
+Renovate runs weekly (Monday before 6am ET). k8s core libraries update monthly. Patch/minor non-k8s Go deps are auto-merged. Major updates require manual review.
+
+---
+
+## Known Constraints & Tech Debt
+
+**No Dockerfile.** The Docker CI workflow (`docker.yaml`) references `build/Dockerfile`, which does not exist. Any attempt to trigger that workflow will fail at the build step.
+
+**BGPAdvertisement has no routerSelector.** This is intentional (documented in code: "Fan-out via routerSelector is intentionally not supported to avoid ambiguous prefix attribution"), but it is an asymmetry from the other BGP resources that operators occasionally find surprising.
+
+**VPC types are less mature.** The VPC package has no unit tests, uses `bool` for status (not `metav1.Condition`), and has commented-out default annotations (`+default:value=false`) that may not work as intended with controller-gen.
+
+**Kubernetes 1.28+ hard requirement.** CEL functions `isIP()` and `isCIDR()` require Kubernetes 1.28+. The CRDs will fail to install on older clusters with a schema validation error. This is not documented in user-facing docs.
+
+**All tools are version-pinned binaries in `./bin/`.** `task tools` must be run before any code generation or linting in a fresh checkout. `go install` is used to install them; there is no lockfile beyond the version suffix in the binary name.
+
+**`CLAUDE.md` is a symlink to `AGENTS.md`.** Both files contain identical content. This is intentional to serve both Claude Code and other AI agents, but can confuse editors and git operations that follow symlinks.
+
+---
+
+## For Claude
+
+**Start here for each concern:**
+
+| Concern                                      | Where to look                                                                                         |
+|----------------------------------------------|-------------------------------------------------------------------------------------------------------|
+| Adding a new CRD                             | `api/bgp/v1alpha1/` — copy an existing `*_types.go`, register in `groupversion_info.go` via `init()` |
+| Understanding a resource's validation rules  | Read the kubebuilder markers in the resource's `*_types.go` file; the CRD YAML is generated from them |
+| Modifying shared types used across resources | `api/bgp/v1alpha1/shared_types.go`                                                                    |
+| Status condition constants                   | Defined in the same file as the resource (e.g., `ConditionTypeReady` is in `peer_types.go`)           |
+| Running tests locally                        | `task test:unit` (unit) or `task test:e2e` (e2e, requires Docker)                                     |
+| Regenerating CRDs after marker changes       | `task generate && task manifests`                                                                      |
+
+**Patterns that differ from Go idioms:**
+- `init()` functions are used extensively to register types with the scheme builder. This is a Kubernetes operator convention, not general Go style.
+- `int64` for ASN fields instead of `uint32` — necessary for valid OpenAPI v3 schema generation.
+- No error returns from type methods — status updates use the Kubernetes condition pattern instead.
+
+**Gotchas:**
+- After any change to `// +kubebuilder:...` markers, both `task generate` and `task manifests` must be run. Forgetting one leaves the code and CRD YAML out of sync.
+- `GOOS=linux` is required when running `go vet` or `go test` locally (the task targets set this). Some types have Linux-specific constraints.
+- `CLAUDE.md` is a symlink. Edit `AGENTS.md` directly; attempts to edit through the symlink will fail.
+- The VRF `BGPVRFInstanceStatus.Routers` field uses `+listType=map +listMapKey=routerName` — different from the standard `+listMapKey=type` used for conditions.

--- a/docs/agents/CONVENTIONS.md
+++ b/docs/agents/CONVENTIONS.md
@@ -1,0 +1,363 @@
+# Conventions
+
+> Cosmos is a Go module defining Kubernetes CRDs and API types for BGP routing and virtual networking. It is API-only — no controllers, no runtime code.
+
+_Last updated: 2026-06-23_
+
+---
+
+## Table of Contents
+
+1. [Core Conventions](#core-conventions)
+   - [Naming](#naming)
+   - [Code Organization](#code-organization)
+   - [Comments and Documentation](#comments-and-documentation)
+   - [Testing](#testing)
+   - [Dependencies and Imports](#dependencies-and-imports)
+   - [Git and Version Control](#git-and-version-control)
+2. [Go Conventions](#go-conventions)
+   - [Module and Package Layout](#module-and-package-layout)
+   - [Type Naming](#type-naming)
+   - [kubebuilder Markers](#kubebuilder-markers)
+   - [Status Conditions](#status-conditions)
+   - [Field Types and Invariants](#field-types-and-invariants)
+   - [JSON Serialization](#json-serialization)
+   - [Code Generation](#code-generation)
+   - [Error Handling](#error-handling)
+   - [Testing](#go-testing)
+   - [Linting and Formatting](#linting-and-formatting)
+3. [YAML Conventions](#yaml-conventions)
+4. [Markdown Conventions](#markdown-conventions)
+5. [For Claude](#for-claude)
+
+---
+
+## Core Conventions
+
+### Naming
+
+**Source files** use `snake_case` with a `_types.go` suffix for CRD type definitions:
+
+```
+router_types.go         ← BGPRouter CRD
+peer_types.go           ← BGPPeer CRD
+shared_types.go         ← types shared across resources in the package
+groupversion_info.go    ← scheme registration (fixed name)
+```
+
+**Test files** use `_test.go` suffix adjacent to the file under test:
+
+```
+router_types_test.go    ← tests for router_types.go
+```
+
+**Generated files** use the `zz_generated.` prefix. Never edit them:
+
+```
+zz_generated.deepcopy.go
+```
+
+**Directories** use lowercase kebab-case. The version is part of the path (`v1alpha1`).
+
+### Code Organization
+
+All API types live under `api/<group>/<version>/`. One `_types.go` file per CRD resource. Types shared across resources in the same package live in `shared_types.go`.
+
+```
+api/
+  bgp/v1alpha1/         ← bgp.miloapis.com API group
+  vpc/v1alpha1/         ← vpc.miloapis.com API group
+config/crd/             ← generated CRD YAML — never edit directly
+config/samples/         ← example resources
+docs/api/               ← human-readable field reference
+docs/enhancements/      ← design proposals
+hack/                   ← code generation support files
+scripts/                ← shell scripts (e2e orchestration)
+test/e2e/               ← Chainsaw e2e tests
+bin/                    ← local dev tools (gitignored)
+```
+
+### Comments and Documentation
+
+**Exported types** require a godoc comment that begins with the type name and ends with a period:
+
+```go
+// BGPRouter defines a logical BGP routing context. It abstracts a processing
+// instance bound to a specific execution context.
+type BGPRouter struct { ... }
+```
+
+**Spec and Status types** follow the "defines the desired/observed state of..." convention:
+
+```go
+// BGPRouterSpec defines the desired state of a BGPRouter.
+type BGPRouterSpec struct { ... }
+
+// BGPRouterStatus defines the observed state of a BGPRouter.
+type BGPRouterStatus struct { ... }
+```
+
+**Enum constants** each get a godoc comment:
+
+```go
+// BGPPolicyActionPermit allows the route and optionally applies set actions.
+BGPPolicyActionPermit BGPPolicyAction = "permit"
+```
+
+**Fields** get a single-line comment above them (not end-of-line). The comment is a description; it does not repeat the field name. For fields with kubebuilder markers, the comment precedes the markers:
+
+```go
+// LocalASN is the BGP Autonomous System Number for this router.
+// +kubebuilder:validation:Required
+LocalASN int64 `json:"localASN"`
+```
+
+Do not write comments that explain what the code obviously does. Write them when the WHY is non-obvious — a hidden constraint, a subtle invariant (e.g., the ASN int64 requirement).
+
+### Testing
+
+- Framework: stdlib `testing` only — no testify, no ginkgo.
+- Style: table-driven tests with `t.Run` for multiple cases; single function for unique behaviors.
+- Test function names: `TestTypeName_Behavior` or `TestTypeName` (e.g., `TestBGPPeerDeepCopy`, `TestUpdatePeerConditions_Established`).
+- Helper constructors (e.g., `newTestPeer()`, `newTestRouter()`) are unexported and defined at the top of the test file.
+- Helper lookup functions (e.g., `findCondition`) are pure functions — no `t.Helper()` required.
+- Tests are in the same package as the production code (white-box, not `_test` suffix package).
+- Unit tests cover: DeepCopy correctness, JSON round-trip, field name verification, and boundary values.
+- E2E tests use [Chainsaw](https://kyverno.github.io/chainsaw/) against a live kind cluster. See `test/e2e/`.
+
+### Dependencies and Imports
+
+- `go.sum` is committed; no vendor directory.
+- Imports are grouped in two blocks (gofmt standard): stdlib then external. No blank line between the groups unless there is an internal package.
+- Aliases follow these conventions:
+  - `metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"` — always aliased
+  - `"k8s.io/apimachinery/pkg/api/meta"` — used unaliased
+- No internal packages — all types are exported API surface.
+
+Adding new dependencies: this repo is API-only. New dependencies must have a clear API type requirement (Kubernetes ecosystem only). Do not add runtime or application dependencies.
+
+### Git and Version Control
+
+**Commit messages** follow [Conventional Commits](https://www.conventionalcommits.org/):
+
+```
+type(scope): short imperative description
+
+Optional body explaining the why.
+```
+
+Types in use: `feat`, `fix`, `refactor`, `chore`, `ci`, `style`.
+Scopes in use: `api`, `bgp`, `vpc`, `e2e`, `docs`, `fmt`, `proto`, `controller`.
+
+**Branch naming**: `type/kebab-case-description`
+
+```
+feat/bgp-peer-status-consolidated
+fix/asn-int64-schema
+refactor/bgp-api-v3
+```
+
+**Merge strategy**: merge commits (PRs land as merge commits; no squash or rebase).
+
+---
+
+## Go Conventions
+
+### Module and Package Layout
+
+- Module path: `go.miloapis.com/cosmos`
+- Go version: 1.26
+- Package name equals the directory's last path segment (`v1alpha1`).
+- One package per API group version. All types for `bgp.miloapis.com/v1alpha1` live in `api/bgp/v1alpha1/`; one `_types.go` file per CRD.
+- No `internal/`, `pkg/`, or `cmd/` packages — this is an API-only module.
+
+### Type Naming
+
+| Construct               | Rule                                          | Example                                        |
+|-------------------------|-----------------------------------------------|------------------------------------------------|
+| CRD resource            | `PascalCase` prefixed with group abbreviation | `BGPRouter`, `BGPPeer`, `VPC`                  |
+| Spec                    | `{Resource}Spec`                              | `BGPRouterSpec`                                |
+| Status                  | `{Resource}Status`                            | `BGPRouterStatus`                              |
+| List                    | `{Resource}List`                              | `BGPRouterList`                                |
+| Enum type               | `{Resource}{Field}` or descriptive noun       | `BGPRouterPhase`, `BGPPeerState`               |
+| Enum constant           | `{TypeName}{Value}`                           | `BGPRouterPhasePending`, `RouterRoleFabric`    |
+| Condition type constant | `ConditionType{Name}` (`string`)              | `ConditionTypeReady`, `ConditionTypeAccepted`  |
+| Idle reason constant    | `IdleReason{Name}` (`string`)                 | `IdleReasonBackOff`                            |
+| Shared struct           | Descriptive PascalCase                        | `RouterTarget`, `AddressFamily`, `LocalSecretRef` |
+| Reference struct        | `{Target}Ref`                                 | `RouterRef`, `TargetRef`                       |
+| Selector struct         | `{Target}Selector`                            | `RouterSelector`                               |
+
+Condition type and reason constants are defined as untyped `string` constants (not a named type) in the same file as the resource they belong to.
+
+### kubebuilder Markers
+
+Every CRD root type requires these markers directly above the type declaration, in this order:
+
+```go
+// +kubebuilder:object:root=true
+// +kubebuilder:subresource:status
+// +kubebuilder:resource:scope=Namespaced,shortName=<abbrev>
+// +kubebuilder:printcolumn:name="...",type="...",JSONPath="..."
+// ... additional printcolumns
+type BGPFoo struct { ... }
+```
+
+Field-level validation markers appear directly above the field comment:
+
+```go
+// LocalASN is the BGP Autonomous System Number for this router.
+// +kubebuilder:validation:Required
+// +kubebuilder:validation:Minimum=1
+// +kubebuilder:validation:Maximum=4294967295
+LocalASN int64 `json:"localASN"`
+```
+
+CEL validation uses `XValidation`:
+
+```go
+// +kubebuilder:validation:XValidation:rule="isIP(self)",message="address must be a valid IPv4 or IPv6 address"
+```
+
+CEL functions `isIP()` and `isCIDR()` require Kubernetes 1.28+.
+
+For lists that are struct maps, use `+listType=map` and `+listMapKey=<key>`:
+
+```go
+// +listType=map
+// +listMapKey=type
+Conditions []metav1.Condition `json:"conditions,omitempty"`
+```
+
+For lists that enforce uniqueness, use `+listType=set`:
+
+```go
+// +listType=set
+Prefixes []string `json:"prefixes"`
+```
+
+### Status Conditions
+
+All status types that surface runtime state include:
+
+1. `ObservedGeneration int64` — set to the `.metadata.generation` the status was computed from.
+2. `Conditions []metav1.Condition` — with `+listType=map` and `+listMapKey=type`.
+
+```go
+type BGPFooStatus struct {
+    // +optional
+    ObservedGeneration int64 `json:"observedGeneration,omitempty"`
+
+    // +listType=map
+    // +listMapKey=type
+    // +optional
+    Conditions []metav1.Condition `json:"conditions,omitempty"`
+}
+```
+
+Condition type constants (`ConditionTypeReady`, `ConditionTypeAccepted`) are `string` constants, not a named type. Use `meta.SetStatusCondition` from `k8s.io/apimachinery/pkg/api/meta` to update conditions (it handles deduplication by type).
+
+### Field Types and Invariants
+
+**ASN fields must use `int64`**, never `int32`. The maximum valid ASN (4294967295) exceeds int32's maximum (2147483647). Using int32 produces an invalid OpenAPI v3 schema.
+
+**Router ID** is an IPv4 address expressed as a string with `// +kubebuilder:validation:Format=ipv4`. Even in IPv6-only underlays it is a logical identifier only.
+
+**Duration fields** use `*metav1.Duration` (pointer, so they can be omitted). CEL validation rules enforce hold-timer semantics.
+
+### JSON Serialization
+
+- Required fields: `json:"fieldName"` (no omitempty).
+- Optional fields: `json:"fieldName,omitempty"`.
+- Inline embedding: `json:",inline"` (no field name, e.g., `metav1.TypeMeta`, `metav1.ObjectMeta`, `RouterTarget`).
+- JSON field names are camelCase matching the Go field name (first letter lowercased).
+- Pointer fields (`*T`) are used exclusively for optional fields that can be absent vs. zero-valued.
+
+### Code Generation
+
+Two generated artifacts — never edit directly:
+
+| Artifact                   | Generator      | Regeneration command |
+|----------------------------|----------------|----------------------|
+| `zz_generated.deepcopy.go` | controller-gen | `task generate`      |
+| `config/crd/*.yaml`        | controller-gen | `task manifests`     |
+
+After changing any kubebuilder markers or adding/removing types: run both `task generate` and `task manifests`.
+
+The copyright/license header for generated files is in `hack/boilerplate.go.txt`.
+
+### Error Handling
+
+This is an API-only module — no request path, no controllers. Error handling is minimal:
+
+- Type methods that update status use the Kubernetes condition pattern (no returned `error`).
+- `fmt.Errorf` is used in status message strings, not for wrapping errors.
+- No panics in this codebase (init() only registers with the scheme builder).
+- No logging — API types have no logging infrastructure.
+
+### Go Testing
+
+- Framework: stdlib `testing` (no external test framework).
+- Table-driven via `t.Run` for parametric cases; dedicated function for single behaviors.
+- Test constructors are named `newTest{TypeName}(...)` (unexported, top of test file).
+- Pure helper functions (e.g., `findCondition`) do not call `t.Helper()` — they are not test helpers, they are utilities.
+- Tests call methods under test then use direct `t.Errorf` / `t.Fatalf` with `got %v, want %v` format.
+- Boundary value tests (especially ASN limits) are regression tests — they are named explicitly as such.
+- Run unit tests: `GOOS=linux go test ./api/bgp/v1alpha1/... -v`
+
+### Linting and Formatting
+
+- Linter: `golangci-lint` v2.1.6 — run via `task lint`.
+- Formatter: `go fmt` runs automatically as a dependency of `task build` and `task test:unit`.
+- `go vet` runs with `GOOS=linux` to catch cross-platform issues.
+- No `.golangci.yml` config file — default golangci-lint settings apply.
+
+---
+
+## YAML Conventions
+
+- All YAML files **must** use the `.yaml` extension. Files with `.yml` will fail the lint check (`task lint` enforces this).
+- YAML is formatted with `yamlfmt` v0.21.0. Run `task lint-fix` to auto-format.
+- CRD manifests in `config/crd/` are generated — do not edit manually.
+- Chainsaw test files follow the Chainsaw schema in `test/e2e/tests/`.
+
+---
+
+## Markdown Conventions
+
+- Markdown tables must have **aligned columns** — pad each cell with spaces so the `|` delimiters line up across all rows, including the separator row. Example:
+
+  ```markdown
+  | Construct  | Rule                           | Example         |
+  |------------|--------------------------------|-----------------|
+  | CRD root   | PascalCase, group prefix       | `BGPRouter`     |
+  | Spec type  | `{Resource}Spec`               | `BGPRouterSpec` |
+  ```
+
+  Not:
+
+  ```markdown
+  | Construct | Rule | Example |
+  |-----------|------|---------|
+  | CRD root | PascalCase, group prefix | `BGPRouter` |
+  ```
+
+- This applies to all `.md` files in the repository: docs, CONVENTIONS.md, ARCHITECTURE.md, CLAUDE.md, and inline docs.
+
+---
+
+## For Claude
+
+- **The single most important rule**: This is API-only Go. No controllers, no runtime, no logging, no error returns from type methods. Every new file goes in `api/<group>/v1alpha1/` and follows the `_types.go` naming pattern.
+- **ASN fields are always `int64`**. Never `int32`. Max ASN (4294967295) overflows int32. This is a hard invariant — the lint tests would catch it but the schema would silently break.
+- **Never edit `zz_generated.deepcopy.go` or `config/crd/*.yaml`**. Run `task generate` / `task manifests` instead.
+- **YAML files use `.yaml` extension only** — `.yml` fails CI.
+- New CRD resource → one `{resource}_types.go` file in the appropriate `api/<group>/v1alpha1/` package. Shared types used across resources in the same package go in `shared_types.go`.
+- Condition type constants are untyped `string` constants (not a named type), defined in the same file as the resource they describe.
+- Status types always include `ObservedGeneration int64` and `Conditions []metav1.Condition` with `+listType=map +listMapKey=type` markers.
+- Tests use stdlib `testing` only — no testify. Table-driven with `t.Run`, same-package (not `_test` suffix).
+- Commit messages follow Conventional Commits: `type(scope): message`. Scopes are `api`, `bgp`, `vpc`, `e2e`, `docs`.
+- **Three most common mistakes to avoid**:
+  1. Using `int32` for ASN fields — always use `int64`.
+  2. Adding omitempty to required fields or omitting it from optional fields.
+  3. Editing generated files directly instead of updating markers and re-running `task generate` + `task manifests`.
+- Comply with `go fmt` (auto-run by task), `go vet` (`GOOS=linux`), and `golangci-lint` defaults.


### PR DESCRIPTION
Add three documentation files and restructure Taskfile task dependencies.

- Add AGENTS.md with project overview, commands, architecture, and conventions reference
- Add ARCHITECTURE.md with full architecture reference: module layout, resource model, data flow, dependencies, testing, CI/CD, and known constraints
- Add CONVENTIONS.md with naming rules, kubebuilder marker patterns, status condition conventions, and Go-specific standards
- Make CLAUDE.md a symlink to AGENTS.md for Claude Code compatibility
- Move tool installation tasks (golangci-lint, controller-gen, chainsaw, yamlfmt) under tools: namespace
- Update task deps to reference tools:<task> instead of top-level task names to avoid circular dependency