### PR TITLE
fix(api): remove galactic0 default from VPCAttachment interface name (3.11)

### DIFF
--- a/api/vpc/v1alpha1/vpcattachment_types.go
+++ b/api/vpc/v1alpha1/vpcattachment_types.go
@@ -46,7 +46,7 @@ type VPCRef struct {
 type VPCAttachmentInterface struct {
 	// Name of the interface (e.g., eth0).
 	// +required
-	// +default:value="galactic0"
+	// +kubebuilder:validation:MinLength=1
 	Name string `json:"name"`
 
 	// A list of IPv4 or IPv6 addresses associated with the interface.

--- a/api/vpc/v1alpha1/vpcattachment_types_test.go
+++ b/api/vpc/v1alpha1/vpcattachment_types_test.go
@@ -1,0 +1,183 @@
+package v1alpha1
+
+import (
+	"encoding/json"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func newTestVPCAttachment() *VPCAttachment {
+	return &VPCAttachment{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "vpc.miloapis.com/v1alpha1",
+			Kind:       "VPCAttachment",
+		},
+		ObjectMeta: metav1.ObjectMeta{Name: "test-attachment"},
+		Spec: VPCAttachmentSpec{
+			VPC: VPCRef{Name: "test-vpc"},
+			Interface: VPCAttachmentInterface{
+				Name:      "eth0",
+				Addresses: []string{"10.0.1.2/24"},
+			},
+		},
+	}
+}
+
+// TestVPCAttachmentDeepCopy verifies that DeepCopy produces an independent copy:
+// mutations to slices and maps in the copy must not affect the original.
+func TestVPCAttachmentDeepCopy(t *testing.T) {
+	orig := newTestVPCAttachment()
+	dup := orig.DeepCopy()
+
+	dup.Spec.VPC.Name = "other-vpc"
+	dup.Spec.Interface.Name = "eth1"
+	dup.Spec.Interface.Addresses[0] = "10.0.2.0/24"
+
+	if orig.Spec.VPC.Name != "test-vpc" {
+		t.Errorf("VPC.Name mutated: got %q", orig.Spec.VPC.Name)
+	}
+	if orig.Spec.Interface.Name != "eth0" {
+		t.Errorf("Interface.Name mutated: got %q", orig.Spec.Interface.Name)
+	}
+	if orig.Spec.Interface.Addresses[0] != "10.0.1.2/24" {
+		t.Errorf("Interface.Addresses[0] mutated: got %q", orig.Spec.Interface.Addresses[0])
+	}
+}
+
+// TestVPCAttachmentDeepCopyNil verifies DeepCopy on a nil pointer returns nil.
+func TestVPCAttachmentDeepCopyNil(t *testing.T) {
+	var a *VPCAttachment
+	if a.DeepCopy() != nil {
+		t.Error("DeepCopy on nil pointer should return nil")
+	}
+}
+
+// TestVPCAttachmentDeepCopyMultipleAddresses verifies that multiple addresses
+// in the copy are independent of the original.
+func TestVPCAttachmentDeepCopyMultipleAddresses(t *testing.T) {
+	orig := newTestVPCAttachment()
+	orig.Spec.Interface.Addresses = []string{"10.0.1.2/24", "fd00::2/64"}
+	dup := orig.DeepCopy()
+
+	dup.Spec.Interface.Addresses[0] = "192.168.0.1/24"
+	dup.Spec.Interface.Addresses[1] = "fd00::99/64"
+
+	if orig.Spec.Interface.Addresses[0] != "10.0.1.2/24" {
+		t.Errorf("Addresses[0] mutated: got %q", orig.Spec.Interface.Addresses[0])
+	}
+	if orig.Spec.Interface.Addresses[1] != "fd00::2/64" {
+		t.Errorf("Addresses[1] mutated: got %q", orig.Spec.Interface.Addresses[1])
+	}
+}
+
+// TestVPCAttachmentJSONRoundTrip verifies that the struct serialises and
+// deserialises through JSON without data loss.
+func TestVPCAttachmentJSONRoundTrip(t *testing.T) {
+	orig := newTestVPCAttachment()
+	orig.Spec.Interface.Addresses = []string{"10.0.1.2/24", "fd00::2/64"}
+
+	data, err := json.Marshal(orig)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+
+	var got VPCAttachment
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+
+	if got.Spec.VPC.Name != orig.Spec.VPC.Name {
+		t.Errorf("VPC.Name: got %q, want %q", got.Spec.VPC.Name, orig.Spec.VPC.Name)
+	}
+	if got.Spec.Interface.Name != orig.Spec.Interface.Name {
+		t.Errorf("Interface.Name: got %q, want %q", got.Spec.Interface.Name, orig.Spec.Interface.Name)
+	}
+	if len(got.Spec.Interface.Addresses) != 2 {
+		t.Fatalf("Addresses len: got %d, want 2", len(got.Spec.Interface.Addresses))
+	}
+	if got.Spec.Interface.Addresses[0] != "10.0.1.2/24" {
+		t.Errorf("Addresses[0]: got %q, want %q", got.Spec.Interface.Addresses[0], "10.0.1.2/24")
+	}
+	if got.Spec.Interface.Addresses[1] != "fd00::2/64" {
+		t.Errorf("Addresses[1]: got %q, want %q", got.Spec.Interface.Addresses[1], "fd00::2/64")
+	}
+}
+
+// TestVPCAttachmentJSONFieldNames verifies JSON key names match the CRD schema.
+func TestVPCAttachmentJSONFieldNames(t *testing.T) {
+	orig := newTestVPCAttachment()
+	data, err := json.Marshal(orig.Spec)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+
+	var m map[string]any
+	if err := json.Unmarshal(data, &m); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+
+	if _, ok := m["vpc"]; !ok {
+		t.Error("expected JSON key \"vpc\" not found")
+	}
+	if _, ok := m["interface"]; !ok {
+		t.Error("expected JSON key \"interface\" not found")
+	}
+
+	iface, _ := m["interface"].(map[string]any)
+	if _, ok := iface["name"]; !ok {
+		t.Error("expected JSON key \"interface.name\" not found")
+	}
+	if _, ok := iface["addresses"]; !ok {
+		t.Error("expected JSON key \"interface.addresses\" not found")
+	}
+}
+
+// TestVPCAttachmentInterfaceNameNoDefault verifies that the interface Name field
+// has no server-side default applied in Go — it must be set explicitly.
+// This is the regression test for section 3.11 of the CRD analysis (the
+// "galactic0" placeholder default was removed).
+func TestVPCAttachmentInterfaceNameNoDefault(t *testing.T) {
+	iface := VPCAttachmentInterface{
+		Addresses: []string{"10.0.1.2/24"},
+	}
+	if iface.Name != "" {
+		t.Errorf("expected zero-value Name to be empty string, got %q (default should not be applied in Go)", iface.Name)
+	}
+
+	data, err := json.Marshal(iface)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+
+	var m map[string]any
+	if err := json.Unmarshal(data, &m); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+
+	if val, ok := m["name"]; ok && val != "" {
+		t.Errorf("expected name to be empty in JSON (no default), got %q", val)
+	}
+}
+
+// TestVPCAttachmentListDeepCopy verifies that VPCAttachmentList.DeepCopy
+// produces independent copies of each item.
+func TestVPCAttachmentListDeepCopy(t *testing.T) {
+	list := &VPCAttachmentList{
+		Items: []VPCAttachment{*newTestVPCAttachment()},
+	}
+	copied := list.DeepCopy()
+	copied.Items[0].Spec.VPC.Name = "mutated-vpc"
+
+	if list.Items[0].Spec.VPC.Name != "test-vpc" {
+		t.Errorf("original list item mutated via copy")
+	}
+}
+
+// TestVPCAttachmentAnnotationConstant verifies the annotation constant value.
+func TestVPCAttachmentAnnotationConstant(t *testing.T) {
+	const want = "k8s.v1alpha1.vpc.miloapis.com/vpc-attachment"
+	if VPCAttachmentAnnotation != want {
+		t.Errorf("VPCAttachmentAnnotation = %q, want %q", VPCAttachmentAnnotation, want)
+	}
+}

--- a/config/crd/bgp.miloapis.com_bgpadvertisements.yaml
+++ b/config/crd/bgp.miloapis.com_bgpadvertisements.yaml
@@ -89,7 +89,6 @@ spec:
                   Communities is the list of BGP communities to attach to advertised prefixes.
                   Format: ASN:NN or IP:NN.
                 items:
-                  maxLength: 32
                   type: string
                 maxItems: 64
                 type: array
@@ -107,7 +106,6 @@ spec:
               prefixes:
                 description: Prefixes is the list of CIDR prefixes to advertise.
                 items:
-                  maxLength: 64
                   type: string
                 maxItems: 256
                 minItems: 1

--- a/config/crd/bgp.miloapis.com_bgppeers.yaml
+++ b/config/crd/bgp.miloapis.com_bgppeers.yaml
@@ -123,7 +123,7 @@ spec:
                 type: string
                 x-kubernetes-validations:
                 - message: holdTime must be 0 or >= 3s
-                  rule: 'duration(self) == duration(''0s'') || duration(self) >= duration(''3s'')'
+                  rule: duration(self) == duration('0s') || duration(self) >= duration('3s')
               keepaliveTime:
                 description: |-
                   KeepaliveTime is the BGP keepalive interval. Must be <= HoldTime / 3.

--- a/config/crd/vpc.miloapis.com_vpcattachments.yaml
+++ b/config/crd/vpc.miloapis.com_vpcattachments.yaml
@@ -46,14 +46,13 @@ spec:
                     description: A list of IPv4 or IPv6 addresses associated with
                       the interface.
                     items:
-                      maxLength: 64
                       type: string
                     maxItems: 16
                     minItems: 1
                     type: array
                   name:
-                    default: galactic0
                     description: Name of the interface (e.g., eth0).
+                    minLength: 1
                     type: string
                 required:
                 - addresses

--- a/config/crd/vpc.miloapis.com_vpcs.yaml
+++ b/config/crd/vpc.miloapis.com_vpcs.yaml
@@ -43,7 +43,6 @@ spec:
                 description: A list of networks in IPv4 or IPv6 CIDR notation associated
                   with the VPC
                 items:
-                  maxLength: 64
                   type: string
                 maxItems: 64
                 minItems: 1

--- a/docs/api/vpc.md
+++ b/docs/api/vpc.md
@@ -62,15 +62,21 @@ The annotation `k8s.v1alpha1.vpc.miloapis.com/vpc-attachment` is set on the atta
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
-| `vpc` | `corev1.ObjectReference` | Yes | Reference to the VPC this attachment belongs to. |
+| `vpc` | `VPCRef` | Yes | Reference to the VPC this attachment belongs to (by name within the same namespace). |
 | `interface` | `VPCAttachmentInterface` | Yes | Network interface configuration. |
+
+**VPCRef**
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `name` | `string` | Yes | Name of the VPC within the same namespace. |
 
 **VPCAttachmentInterface**
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
-| `name` | `string` | Yes | Interface name on the workload (e.g. `galactic0`). Default: `galactic0`. |
-| `addresses` | `[]string` | Yes | IPv4 or IPv6 addresses assigned to the interface. Minimum 1. |
+| `name` | `string` | Yes | Interface name on the workload (e.g. `eth0`). Must be non-empty. No default is applied — callers must always set this field explicitly. |
+| `addresses` | `[]string` | Yes | IPv4 or IPv6 CIDR addresses assigned to the interface. Minimum 1, maximum 16. |
 
 #### Status
 

--- a/test/e2e/tests/vpc-crd-schema/chainsaw-test.yaml
+++ b/test/e2e/tests/vpc-crd-schema/chainsaw-test.yaml
@@ -4,10 +4,10 @@ metadata:
   name: vpc-crd-schema
 spec:
   description: >
-    Verify schema validation, storage, and field defaults for VPC and VPCAttachment CRDs.
-    Tests that valid resources are accepted and stored, invalid resources are rejected by
-    the API server, and server-side defaults are applied correctly. Does not require the
-    BGP operator to be running — CRD schema is enforced by the API server alone.
+    Verify schema validation and storage for VPC and VPCAttachment CRDs. Tests that valid
+    resources are accepted and stored, invalid resources are rejected by the API server, and
+    all required fields are enforced. Does not require the BGP operator to be running — CRD
+    schema is enforced by the API server alone.
   steps:
     - name: create-valid-vpc
       try:
@@ -158,16 +158,16 @@ spec:
               fi
               echo "OK: interface name=$IFACE addresses=[$A0, $A1]"
 
-    - name: verify-interface-name-default
+    - name: reject-vpcattachment-missing-interface-name
       try:
         - script:
             content: |
-              set -e
-              kubectl apply -n "$NAMESPACE" -f - <<EOF
+              set +e
+              OUTPUT=$(kubectl apply -n "$NAMESPACE" -f - 2>&1 <<'EOF'
               apiVersion: vpc.miloapis.com/v1alpha1
               kind: VPCAttachment
               metadata:
-                name: e2e-default-iface
+                name: e2e-invalid-no-iface-name
               spec:
                 vpc:
                   name: e2e-valid-vpc
@@ -175,14 +175,16 @@ spec:
                   addresses:
                     - "10.0.2.3/24"
               EOF
-              NAME=$(kubectl get vpcattachment e2e-default-iface -n "$NAMESPACE" \
-                -o jsonpath='{.spec.interface.name}')
-              kubectl delete vpcattachment e2e-default-iface -n "$NAMESPACE"
-              if [ "$NAME" != "galactic0" ]; then
-                echo "ERROR: expected interface name default 'galactic0' but got '$NAME'"
+              )
+              EXIT=$?
+              set -e
+              if [ "$EXIT" -eq 0 ]; then
+                echo "ERROR: expected rejection of VPCAttachment with missing interface.name but resource was accepted"
+                kubectl delete vpcattachment e2e-invalid-no-iface-name -n "$NAMESPACE" 2>/dev/null || true
                 exit 1
               fi
-              echo "OK: interface name defaulted to galactic0"
+              echo "OK: missing interface.name correctly rejected (no default applied)"
+              echo "Server response: $OUTPUT"
 
     - name: reject-vpcattachment-empty-addresses
       try:


### PR DESCRIPTION
## Summary

- Removes the `galactic0` placeholder default from `VPCAttachmentInterface.Name` — identified in the SRv6/EVPN CRD analysis (section 3.11) as a test value that should not exist in a production API
- Adds `+kubebuilder:validation:MinLength=1` so the field rejects empty strings at admission time
- Regenerates all CRD manifests from source (also cleans up stale `maxLength` annotations on string array items in BGP/VPC CRDs that had no backing source markers, and normalises CEL rule quoting in the BGPPeer CRD)

## Changes

| File | What changed |
|------|-------------|
| `api/vpc/v1alpha1/vpcattachment_types.go` | Drop `+default:value="galactic0"`, add `+kubebuilder:validation:MinLength=1` |
| `api/vpc/v1alpha1/vpcattachment_types_test.go` | New: DeepCopy, JSON round-trip, field name, and no-default regression tests (8 tests) |
| `config/crd/vpc.miloapis.com_vpcattachments.yaml` | Regenerated: `default: galactic0` removed, `minLength: 1` added |
| `config/crd/bgp.miloapis.com_bgpadvertisements.yaml` | Regenerated: stale `maxLength` on string items removed |
| `config/crd/bgp.miloapis.com_bgppeers.yaml` | Regenerated: CEL rule quoting normalised |
| `config/crd/vpc.miloapis.com_vpcs.yaml` | Regenerated: stale `maxLength` on string items removed |
| `docs/api/vpc.md` | Fix `VPCRef` type, remove `galactic0` mention, clarify `name` is required with no default |
| `test/e2e/tests/vpc-crd-schema/chainsaw-test.yaml` | Replace `verify-interface-name-default` step with `reject-vpcattachment-missing-interface-name` |

## Test plan

- [x] `go test ./api/vpc/...` — 8 new unit tests pass
- [x] `go test ./...` (non-e2e) — all pass, no regressions
- [ ] E2E: `test:e2e` — `vpc-crd-schema` chainsaw test now verifies omitting `interface.name` is rejected instead of verifying a `galactic0` default

🤖 Generated with [Claude Code](https://claude.com/claude-code)