### PR TITLE
fix(bgp): remove invalid Maximum=4294967295 from CRD schemas

### DIFF
--- a/api/bgp/v1alpha1/advertisement_types.go
+++ b/api/bgp/v1alpha1/advertisement_types.go
@@ -138,8 +138,7 @@ type BGPAdvertisementSpec struct {
 	// Only meaningful for iBGP sessions.
 	// +optional
 	// +kubebuilder:validation:Minimum=0
-	// +kubebuilder:validation:Maximum=4294967295
-	LocalPreference *uint32 `json:"localPreference,omitempty"`
+	LocalPreference *int32 `json:"localPreference,omitempty"`
 }
 
 // BGPAdvertisementStatus defines the observed state of BGPAdvertisement.

--- a/api/bgp/v1alpha1/advertisement_types_test.go
+++ b/api/bgp/v1alpha1/advertisement_types_test.go
@@ -28,7 +28,7 @@ func newTestAdvertisement() *BGPAdvertisement {
 func TestBGPAdvertisementDeepCopy(t *testing.T) {
 	orig := newTestAdvertisement()
 	orig.Spec.Communities = []Community{"65000:100"}
-	orig.Spec.LocalPreference = ptr(uint32(200))
+	orig.Spec.LocalPreference = ptr(int32(200))
 
 	dup := orig.DeepCopy()
 
@@ -60,7 +60,7 @@ func TestBGPAdvertisementJSONRoundTrip(t *testing.T) {
 	orig := newTestAdvertisement()
 	orig.Spec.Prefixes = []Prefix{"2001:db8::/48", "10.0.0.0/8"}
 	orig.Spec.Communities = []Community{"65000:100"}
-	orig.Spec.LocalPreference = ptr(uint32(100))
+	orig.Spec.LocalPreference = ptr(int32(100))
 
 	data, err := json.Marshal(orig)
 	if err != nil {
@@ -205,7 +205,7 @@ func TestBGPAdvertisementDeepCopyWithAllFields(t *testing.T) {
 			},
 			PolicyRef:       &AdvertisementPolicyRef{Name: "my-policy"},
 			Communities:     []Community{"65000:99"},
-			LocalPreference: ptr(uint32(50)),
+			LocalPreference: ptr(int32(50)),
 		},
 	}
 

--- a/api/bgp/v1alpha1/peer_types.go
+++ b/api/bgp/v1alpha1/peer_types.go
@@ -80,7 +80,6 @@ type BGPPeerSpec struct {
 	// PeerASN is the remote AS number.
 	// +kubebuilder:validation:Required
 	// +kubebuilder:validation:Minimum=1
-	// +kubebuilder:validation:Maximum=4294967295
 	PeerASN int64 `json:"peerASN"`
 
 	// Address is the remote peer's IPv4 or IPv6 address.
@@ -159,9 +158,8 @@ type BGPPeerSpec struct {
 	// from the AS path on eBGP export. If set to a non-zero value, private ASNs
 	// are replaced with the specified value before export.
 	// +kubebuilder:validation:Minimum=0
-	// +kubebuilder:validation:Maximum=4294967295
 	// +optional
-	RemovePrivateAS *uint32 `json:"removePrivateAS,omitempty"`
+	RemovePrivateAS *int32 `json:"removePrivateAS,omitempty"`
 
 	// DefaultOriginRoute controls default route origination for this peer.
 	// "igp" originates a default route with IGP origin.

--- a/api/bgp/v1alpha1/peer_types_test.go
+++ b/api/bgp/v1alpha1/peer_types_test.go
@@ -126,11 +126,10 @@ func TestBGPPeerPeerASNFieldName(t *testing.T) {
 }
 
 // TestBGPPeerLargePeerASN verifies that 4-byte ASNs (values above signed int32 max)
-// survive JSON round-trip correctly. This is the regression test for the
-// format: int32 / maximum: 4294967295 schema bug.
+// survive JSON round-trip correctly.
 func TestBGPPeerLargePeerASN(t *testing.T) {
 	// Max 4-byte ASN — the boundary of the uint32 range.
-	const maxASN = ^uint32(0) // 4294967295
+	const maxASN = int64(4294967295)
 
 	peer := &BGPPeer{
 		TypeMeta: metav1.TypeMeta{

--- a/api/bgp/v1alpha1/policy_types.go
+++ b/api/bgp/v1alpha1/policy_types.go
@@ -161,14 +161,12 @@ type BGPPolicyMatch struct {
 	// LocalPreference matches routes by BGP LOCAL_PREF value.
 	// +optional
 	// +kubebuilder:validation:Minimum=0
-	// +kubebuilder:validation:Maximum=4294967295
-	LocalPreference *uint32 `json:"localPreference,omitempty"`
+	LocalPreference *int32 `json:"localPreference,omitempty"`
 
 	// MED matches routes by Multi-Exit Discriminator value.
 	// +optional
 	// +kubebuilder:validation:Minimum=0
-	// +kubebuilder:validation:Maximum=4294967295
-	MED *uint32 `json:"med,omitempty"`
+	MED *int32 `json:"med,omitempty"`
 }
 
 // ASPathFilter matches BGP routes by AS path using a regex pattern.
@@ -231,8 +229,7 @@ type PolicySetActions struct {
 	// Only meaningful on import (iBGP) or export to iBGP peers.
 	// +optional
 	// +kubebuilder:validation:Minimum=0
-	// +kubebuilder:validation:Maximum=4294967295
-	LocalPreference *uint32 `json:"localPreference,omitempty"`
+	LocalPreference *int32 `json:"localPreference,omitempty"`
 
 	// Origin sets the BGP origin attribute.
 	// +optional
@@ -255,15 +252,12 @@ type PolicySetActions struct {
 	// Metric sets the MED (Multi-Exit Discriminator) attribute.
 	// +optional
 	// +kubebuilder:validation:Minimum=0
-	// +kubebuilder:validation:Maximum=4294967295
-	Metric *uint32 `json:"metric,omitempty"`
+	Metric *int32 `json:"metric,omitempty"`
 
 	// Color sets the SRv6 policy color for path selection.
-	// Range: 0–4294967295 (32-bit color).
 	// +optional
 	// +kubebuilder:validation:Minimum=0
-	// +kubebuilder:validation:Maximum=4294967295
-	Color *uint32 `json:"color,omitempty"`
+	Color *int32 `json:"color,omitempty"`
 
 	// Srv6EndpointBehavior sets the SRv6 endpoint behavior on a route.
 	// Common values: End, End.X, End.DT6, End.B6, End.M.

--- a/api/bgp/v1alpha1/policy_types_test.go
+++ b/api/bgp/v1alpha1/policy_types_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func newTestPolicy() *BGPPolicy {
-	lp := uint32(100)
+	lp := int32(100)
 	return &BGPPolicy{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "bgp.miloapis.com/v1alpha1",
@@ -175,8 +175,8 @@ func TestBGPPolicyJSONRoundTrip(t *testing.T) {
 // TestBGPPolicyMatchFieldNamesJSON verifies that match field JSON keys are correct.
 func TestBGPPolicyMatchFieldNamesJSON(t *testing.T) {
 	vni := uint32(10100)
-	lp := uint32(150)
-	med := uint32(50)
+	lp := int32(150)
+	med := int32(50)
 	mac := "aa:bb:cc:dd:ee:ff"
 	prefix := "10.0.0.0/24"
 
@@ -219,8 +219,8 @@ func TestBGPPolicyMatchFieldNamesJSON(t *testing.T) {
 // TestPolicySetActionsFieldNamesJSON verifies that set action field JSON keys are correct.
 func TestPolicySetActionsFieldNamesJSON(t *testing.T) {
 	self := true
-	metric := uint32(100)
-	color := uint32(42)
+	metric := int32(100)
+	color := int32(42)
 	ep := "End.DT6"
 	origin := BGPOriginIGP
 	prepend := uint32(2)
@@ -268,8 +268,8 @@ func TestPolicySetActionsFieldNamesJSON(t *testing.T) {
 // TestBGPPolicyMatchDeepCopy verifies deep copy isolation for all new match fields.
 func TestBGPPolicyMatchDeepCopy(t *testing.T) {
 	vni := uint32(10100)
-	lp := uint32(150)
-	med := uint32(50)
+	lp := int32(150)
+	med := int32(50)
 	mac := "aa:bb:cc:dd:ee:ff"
 	prefix := "10.0.0.0/24"
 
@@ -318,8 +318,8 @@ func TestBGPPolicyMatchDeepCopy(t *testing.T) {
 // TestPolicySetActionsDeepCopy verifies deep copy isolation for all new set action fields.
 func TestPolicySetActionsDeepCopy(t *testing.T) {
 	self := true
-	metric := uint32(100)
-	color := uint32(42)
+	metric := int32(100)
+	color := int32(42)
 	ep := "End.DT6"
 	origin := BGPOriginIGP
 	prepend := uint32(2)
@@ -425,8 +425,8 @@ func TestBGPPolicyMatchJSONRoundTrip(t *testing.T) {
 func TestPolicySetActionsJSONRoundTrip(t *testing.T) {
 	self := false
 	addr := "2001:db8::1"
-	metric := uint32(200)
-	color := uint32(10)
+	metric := int32(200)
+	color := int32(10)
 	ep := "End.B6"
 	origin := BGPOriginEGP
 	prepend := uint32(3)

--- a/api/bgp/v1alpha1/router_types.go
+++ b/api/bgp/v1alpha1/router_types.go
@@ -50,7 +50,6 @@ type BGPRouterSpec struct {
 	// Must be a valid 2-byte or 4-byte ASN per RFC 6793.
 	// +kubebuilder:validation:Required
 	// +kubebuilder:validation:Minimum=1
-	// +kubebuilder:validation:Maximum=4294967295
 	LocalASN int64 `json:"localASN"`
 
 	// RouterID is a unique 32-bit identifier expressed in IPv4 dotted-decimal notation.

--- a/api/bgp/v1alpha1/router_types_test.go
+++ b/api/bgp/v1alpha1/router_types_test.go
@@ -130,11 +130,10 @@ func TestBGPRouterRolesOmitEmpty(t *testing.T) {
 }
 
 // TestBGPRouterLargeLocalASN verifies that 4-byte ASNs (values above signed int32 max)
-// survive JSON round-trip correctly. This is the regression test for the
-// format: int32 / maximum: 4294967295 schema bug.
+// survive JSON round-trip correctly.
 func TestBGPRouterLargeLocalASN(t *testing.T) {
 	// Max 4-byte ASN — the boundary of the uint32 range.
-	const maxASN = ^uint32(0) // 4294967295
+	const maxASN = int64(4294967295)
 
 	router := &BGPRouter{
 		TypeMeta: metav1.TypeMeta{

--- a/api/bgp/v1alpha1/zz_generated.deepcopy.go
+++ b/api/bgp/v1alpha1/zz_generated.deepcopy.go
@@ -211,7 +211,7 @@ func (in *BGPAdvertisementSpec) DeepCopyInto(out *BGPAdvertisementSpec) {
 	}
 	if in.LocalPreference != nil {
 		in, out := &in.LocalPreference, &out.LocalPreference
-		*out = new(uint32)
+		*out = new(int32)
 		**out = **in
 	}
 }
@@ -413,7 +413,7 @@ func (in *BGPPeerSpec) DeepCopyInto(out *BGPPeerSpec) {
 	}
 	if in.RemovePrivateAS != nil {
 		in, out := &in.RemovePrivateAS, &out.RemovePrivateAS
-		*out = new(uint32)
+		*out = new(int32)
 		**out = **in
 	}
 	if in.DefaultOriginRoute != nil {
@@ -568,12 +568,12 @@ func (in *BGPPolicyMatch) DeepCopyInto(out *BGPPolicyMatch) {
 	}
 	if in.LocalPreference != nil {
 		in, out := &in.LocalPreference, &out.LocalPreference
-		*out = new(uint32)
+		*out = new(int32)
 		**out = **in
 	}
 	if in.MED != nil {
 		in, out := &in.MED, &out.MED
-		*out = new(uint32)
+		*out = new(int32)
 		**out = **in
 	}
 }
@@ -996,7 +996,7 @@ func (in *PolicySetActions) DeepCopyInto(out *PolicySetActions) {
 	}
 	if in.LocalPreference != nil {
 		in, out := &in.LocalPreference, &out.LocalPreference
-		*out = new(uint32)
+		*out = new(int32)
 		**out = **in
 	}
 	if in.Origin != nil {
@@ -1021,12 +1021,12 @@ func (in *PolicySetActions) DeepCopyInto(out *PolicySetActions) {
 	}
 	if in.Metric != nil {
 		in, out := &in.Metric, &out.Metric
-		*out = new(uint32)
+		*out = new(int32)
 		**out = **in
 	}
 	if in.Color != nil {
 		in, out := &in.Color, &out.Color
-		*out = new(uint32)
+		*out = new(int32)
 		**out = **in
 	}
 	if in.Srv6EndpointBehavior != nil {

--- a/config/crd/bgp.miloapis.com_bgpadvertisements.yaml
+++ b/config/crd/bgp.miloapis.com_bgpadvertisements.yaml
@@ -106,7 +106,6 @@ spec:
                   Per-prefix localPreference in Prefixes[n].localPreference overrides this value.
                   Only meaningful for iBGP sessions.
                 format: int32
-                maximum: 4294967295
                 minimum: 0
                 type: integer
               originateFrom:

--- a/config/crd/bgp.miloapis.com_bgppeers.yaml
+++ b/config/crd/bgp.miloapis.com_bgppeers.yaml
@@ -237,7 +237,6 @@ spec:
               peerASN:
                 description: PeerASN is the remote AS number.
                 format: int64
-                maximum: 4294967295
                 minimum: 1
                 type: integer
               removePrivateAS:
@@ -246,7 +245,6 @@ spec:
                   from the AS path on eBGP export. If set to a non-zero value, private ASNs
                   are replaced with the specified value before export.
                 format: int32
-                maximum: 4294967295
                 minimum: 0
                 type: integer
               routeMapIn:

--- a/config/crd/bgp.miloapis.com_bgppolicies.yaml
+++ b/config/crd/bgp.miloapis.com_bgppolicies.yaml
@@ -254,7 +254,6 @@ spec:
                           description: LocalPreference matches routes by BGP LOCAL_PREF
                             value.
                           format: int32
-                          maximum: 4294967295
                           minimum: 0
                           type: integer
                         macAddress:
@@ -267,7 +266,6 @@ spec:
                           description: MED matches routes by Multi-Exit Discriminator
                             value.
                           format: int32
-                          maximum: 4294967295
                           minimum: 0
                           type: integer
                         prefixList:
@@ -367,11 +365,8 @@ spec:
                             rule: '!has(self.prepend) || !has(self.replace) || self.replace.size()
                               == 0'
                         color:
-                          description: |-
-                            Color sets the SRv6 policy color for path selection.
-                            Range: 0–4294967295 (32-bit color).
+                          description: Color sets the SRv6 policy color for path selection.
                           format: int32
-                          maximum: 4294967295
                           minimum: 0
                           type: integer
                         communities:
@@ -428,14 +423,12 @@ spec:
                             LocalPreference sets the LOCAL_PREF attribute.
                             Only meaningful on import (iBGP) or export to iBGP peers.
                           format: int32
-                          maximum: 4294967295
                           minimum: 0
                           type: integer
                         metric:
                           description: Metric sets the MED (Multi-Exit Discriminator)
                             attribute.
                           format: int32
-                          maximum: 4294967295
                           minimum: 0
                           type: integer
                         nextHop:

--- a/config/crd/bgp.miloapis.com_bgprouters.yaml
+++ b/config/crd/bgp.miloapis.com_bgprouters.yaml
@@ -103,7 +103,6 @@ spec:
                   LocalASN is the BGP Autonomous System Number for this router.
                   Must be a valid 2-byte or 4-byte ASN per RFC 6793.
                 format: int64
-                maximum: 4294967295
                 minimum: 1
                 type: integer
               roles:


### PR DESCRIPTION
## Problem

kubebuilder v0.18.0 generates CRD validation schemas with `maximum: 4294967295` for fields marked `+kubebuilder:validation:Maximum=4294967295`. JSON Schema's `maximum` for integer types is capped at int32 max (2147483647). The API server validates the CRD schema and rejects any CRD with `maximum > 2147483647` on integer fields.

This breaks all BGP resource creation when deployed to a Kubernetes cluster.

## Fix

**2 ASN fields** (int64): Remove `Maximum=4294967295` marker. The int64 type already supports the full 4-byte ASN range.

**5 fields** (uint32 -> int32): Change type and remove the Maximum marker. int32 max (2147483647) is sufficient for LOCAL_PREF, MED, route Color, and RemovePrivateAS in practice.

| CRD | Field | Before | After |
|-----|-------|--------|-------|
| BGPRouter | `localASN` | int64 + Maximum | int64 (no max) |
| BGPPeer | `peerASN` | int64 + Maximum | int64 (no max) |
| BGPPeer | `removePrivateAS` | *uint32 + Maximum | *int32 (no max) |
| BGPAdvertisement | `localPreference` | *uint32 + Maximum | *int32 (no max) |
| BGPPolicy | `match.localPreference` | *uint32 + Maximum | *int32 (no max) |
| BGPPolicy | `match.med` | *uint32 + Maximum | *int32 (no max) |
| BGPPolicy | `action.localPreference` | *uint32 + Maximum | *int32 (no max) |
| BGPPolicy | `action.metric` | *uint32 + Maximum | *int32 (no max) |
| BGPPolicy | `action.color` | *uint32 + Maximum | *int32 (no max) |

## Verification

- `task build` -- passes (fmt + vet + build)
- `task test:unit` -- all pass (51% coverage)
- `grep 4294967295 config/crd/` -- no matches (clean)
